### PR TITLE
TOAST SDK 유니티, 윈도우 버전별 다운로드 링크 위치 변경

### DIFF
--- a/en/toast-sdk/release-notes-unity.md
+++ b/en/toast-sdk/release-notes-unity.md
@@ -1,6 +1,7 @@
 ## TOAST > User Guide for TOAST SDK > Release Notes > Unity
 
-## 0.22.0 (2021.04.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
+## 0.22.0 (2021.04.27)
+Download : [toast-sdk-unity-0.22.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
 
 ### Added
 
@@ -12,7 +13,8 @@
 * Android : 0.25.0
 * iOS : 0.27.2
 
-## 0.21.6 (2021.03.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
+## 0.21.6 (2021.03.23)
+Download : [toast-sdk-unity-0.21.6.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
 
 ### Fixed
 
@@ -22,19 +24,22 @@
 
 - iOS : 0.27.2
 
-## 0.21.5 (2021.01.15) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
+## 0.21.5 (2021.01.15)
+Download : [toast-sdk-unity-0.21.5.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
 
 ### plugin version
 
 - Android : 0.24.4
 
-## 0.21.4 (2020.12.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
+## 0.21.4 (2020.12.10)
+Download : [toast-sdk-unity-0.21.4.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
 
 ### plugin version
 
 - Android : 0.24.3
 
-## 0.21.3 (2020.11.24) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
+## 0.21.3 (2020.11.24)
+Download : [toast-sdk-unity-0.21.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
 
 ### plugin version
 
@@ -49,13 +54,15 @@
 
 - Galaxy Store 추가
 
-## 0.21.2 (2020.10.05) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
+## 0.21.2 (2020.10.05)
+Download : [toast-sdk-unity-0.21.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
 
 ### plugin version
 
 - Android : 0.23.2
 
-## 0.21.1 (2020.09.16) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
+## 0.21.1 (2020.09.16)
+Download : [toast-sdk-unity-0.21.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
 
 ### plugin version
 
@@ -66,7 +73,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.3 (2020.07.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
+## 0.20.3 (2020.07.10)
+Download : [toast-sdk-unity-0.20.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
 
 ### plugin version
 
@@ -77,7 +85,8 @@
 
 - InstanceLogger 사용시, 암호화키를 호출하지 않는 버그 수정
 
-## 0.20.2 (2020.07.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
+## 0.20.2 (2020.07.08)
+Download : [toast-sdk-unity-0.20.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
 
 ### plugin version
 
@@ -88,7 +97,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.1 (2020.06.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
+## 0.20.1 (2020.06.23)
+Download : [toast-sdk-unity-0.20.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
 
 ### plugin version
 
@@ -104,7 +114,8 @@
 - Windows 환경에서 C++ DLL 의존성 제거
 
 
-## 0.20.0 (2020.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
+## 0.20.0 (2020.03.26)
+Download : [toast-sdk-unity-0.20.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
 
 ### plugin version
 
@@ -115,19 +126,22 @@
 
 - CrashFilter관련 처리에서 Exception 이슈
 
-## 0.19.1 (2020.01.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
+## 0.19.1 (2020.01.23)
+Download : [toast-sdk-unity-0.19.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
 
 ### Fixed
 
 - OnHandleException 콜백 호출 이슈
 
-## 0.19.0 (2019.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
+## 0.19.0 (2019.12.27)
+Download : [toast-sdk-unity-0.19.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
 
 ### Added
 
 - Unity Play Services Resolver 적용
 
-## 0.18.0 (2019.12.06) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
+## 0.18.0 (2019.12.06)
+Download : [toast-sdk-unity-0.18.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
 
 ### Common
 
@@ -135,13 +149,15 @@
 - Android 0.19.4 aar 포함해서 배포
 - Native Plugin (Windows, MacOS) 배포
 
-## 0.17.0 (2019.10.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
+## 0.17.0 (2019.10.02)
+Download : [toast-sdk-unity-0.17.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
 
 ### TOAST IAP
 
 - 구매 요청시 사용자 데이터 설정 기능 추가
 
-## 0.16.0 (2019.08.28) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
+## 0.16.0 (2019.08.28)
+Download : [toast-sdk-unity-0.16.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
 
 ### TOAST IAP
 
@@ -149,13 +165,15 @@
 
 - 소비성 구독 상품 추가
 
-## 0.15.1 (2019.07.29) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
+## 0.15.1 (2019.07.29)
+Download : [toast-sdk-unity-0.15.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
 
 ### Common
 
 - iOS 0.16.1 framework 적용
 
-## 0.15.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
+## 0.15.0 (2019.07.23)
+Download : [toast-sdk-unity-0.15.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
 
 ### TOAST IAP
 
@@ -163,7 +181,8 @@
 
 - ActivedPurchases -> ActivatedPurchses
 
-## 0.14.0 (2019.07.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
+## 0.14.0 (2019.07.02)
+Download : [toast-sdk-unity-0.14.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
 
 ### TOAST Log & Crash
 
@@ -179,7 +198,8 @@
 
 - ActivedPurchases 추가
 
-## 0.13.1 (2019.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
+## 0.13.1 (2019.03.26)
+Download : [toast-sdk-unity-0.13.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
 
 ### TOAST Log & Crash
 
@@ -193,7 +213,8 @@
 
 - Fixed a issue that sends a unexpected SDK exception when message is empty in Android.
 
-## 0.13.0 (2019.02.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
+## 0.13.0 (2019.02.26)
+Download : [toast-sdk-unity-0.13.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
 
 ### TOAST Log & Crash
 
@@ -201,7 +222,8 @@
 
 - Add a feature that filter crash logs
 
-## 0.12.0 (2019.01.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
+## 0.12.0 (2019.01.08)
+Download : [toast-sdk-unity-0.12.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
 
 ### TOAST IAP
 
@@ -209,7 +231,8 @@
 
 - Add module
 
-## 0.11.0 (2018.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
+## 0.11.0 (2018.12.27)
+Download : [toast-sdk-unity-0.11.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
 
 ### TOAST Log & Crash
 
@@ -218,7 +241,8 @@
 - Add a feature that sends automatically unexpected exception logs that occurs in Unity
 - SetCrashListener API
 
-## 0.10.0 (2018.11.20) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
+## 0.10.0 (2018.11.20)
+Download : [toast-sdk-unity-0.10.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
 
 ### TOAST Log & Crash
 
@@ -232,7 +256,8 @@
 - Removed mainTemplate.gradle from Unity Package
   - See guide for setting of mainTemplate.gradle
 
-## 0.9.0 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
+## 0.9.0 (2018.09.04)
+Download : [toast-sdk-unity-0.9.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
 
 ### TOAST Log & Crash
 

--- a/en/toast-sdk/release-notes-windows.md
+++ b/en/toast-sdk/release-notes-windows.md
@@ -1,6 +1,8 @@
 ## TOAST > User Guide for TOAST SDK > Release Notes > Windows C++
 
-## 0.9.4.3 (2019.10.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
+## 0.9.4.3 (2019.10.10)
+Download : [toast-sdk-windows-0.9.4.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
+
 
 ### TOAST Log & Crash
 
@@ -8,7 +10,8 @@
 
 * x86에서 pure virtual call / invalid parameter 크래쉬로그가 남지 않는 현상 처리
 
-## 0.9.3.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
+## 0.9.3.0 (2019.07.23)
+Download : [toast-sdk-windows-0.9.3.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
 
 ### TOAST Log & Crash
 
@@ -22,7 +25,8 @@
 	* visual studio 2015 (vc14) 버전 제공
 * xp 버전 제공 
 
-## 0.9.0.12 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
+## 0.9.0.12 (2018.09.04)
+Download : [toast-sdk-windows-0.9.0.12.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
 
 ### TOAST Log & Crash
 

--- a/ja/toast-sdk/release-notes-unity.md
+++ b/ja/toast-sdk/release-notes-unity.md
@@ -1,6 +1,7 @@
 ## TOAST > TOAST SDK 使用ガイド > リリースノート > Unity
 
-## 0.22.0 (2021.04.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
+## 0.22.0 (2021.04.27)
+Download : [toast-sdk-unity-0.22.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
 
 ### 機能追加
 
@@ -12,7 +13,8 @@
 * Android : 0.25.0
 * iOS : 0.27.2
 
-## 0.21.6 (2021.03.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
+## 0.21.6 (2021.03.23)
+Download : [toast-sdk-unity-0.21.6.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
 
 ### バグ修正
 
@@ -22,19 +24,22 @@
 
 - iOS : 0.27.2
 
-## 0.21.5 (2021.01.15) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
+## 0.21.5 (2021.01.15)
+Download : [toast-sdk-unity-0.21.5.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
 
 ### plugin version
 
 - Android : 0.24.4
 
-## 0.21.4 (2020.12.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
+## 0.21.4 (2020.12.10)
+Download : [toast-sdk-unity-0.21.4.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
 
 ### plugin version
 
 - Android : 0.24.3
 
-## 0.21.3 (2020.11.24) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
+## 0.21.3 (2020.11.24)
+Download : [toast-sdk-unity-0.21.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
 
 ### plugin version
 
@@ -49,13 +54,16 @@
 
 - Galaxy Store追加
 
-## 0.21.2 (2020.10.05) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
+## 0.21.2 (2020.10.05)
+Download : [toast-sdk-unity-0.21.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
 
 ### plugin version
 
 - Android : 0.23.2
 
-## 0.21.1 (2020.09.16) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
+## 0.21.1 (2020.09.16)
+Download : [toast-sdk-unity-0.21.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
+
 
 ### plugin version
 
@@ -66,7 +74,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.3 (2020.07.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
+## 0.20.3 (2020.07.10)
+Download : [toast-sdk-unity-0.20.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
 
 ### plugin version
 
@@ -77,7 +86,8 @@
 
 - InstanceLogger使用時、暗号化キーを呼び出さないバグを修正
 
-## 0.20.2 (2020.07.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
+## 0.20.2 (2020.07.08)
+Download : [toast-sdk-unity-0.20.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
 
 ### plugin version
 
@@ -88,7 +98,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.1 (2020.06.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
+## 0.20.1 (2020.06.23)
+Download : [toast-sdk-unity-0.20.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
 
 ### plugin version
 
@@ -103,7 +114,8 @@
 
 - Windows環境で C++ DLL依存性を除去
 
-## 0.20.0 (2020.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
+## 0.20.0 (2020.03.26)
+Download : [toast-sdk-unity-0.20.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
 
 ### plugin version
 
@@ -114,19 +126,22 @@
 
 - CrashFilter関連処理での Exceptionの問題を修正
 
-## 0.19.1 (2020.01.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
+## 0.19.1 (2020.01.23)
+Download : [toast-sdk-unity-0.19.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
 
 ### バグ修正
 
 - OnHandleException コールバック呼び出しの問題を修正
 
-## 0.19.0 (2019.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
+## 0.19.0 (2019.12.27)
+Download : [toast-sdk-unity-0.19.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
 
 ### 追加事項
 
 - Unity Play Services Resolver 適用
 
-## 0.18.0 (2019.12.06) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
+## 0.18.0 (2019.12.06)
+Download : [toast-sdk-unity-0.18.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
 
 ### 共通
 
@@ -134,13 +149,15 @@
 - Android 0.19.4 aar 含めて配布
 - Native Plugin (Windows, MacOS) 配布
 
-## 0.17.0 (2019.10.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
+## 0.17.0 (2019.10.02)
+Download : [toast-sdk-unity-0.17.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
 
 ### TOAST IAP
 
 - 購入リクエスト時にユーザーデータ設定機能追加
 
-## 0.16.0 (2019.08.28) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
+## 0.16.0 (2019.08.28)
+Download : [toast-sdk-unity-0.16.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
 
 ### TOAST IAP
 
@@ -148,13 +165,15 @@
 
 - 消費性サブスクリプションプロダクトの追加
 
-## 0.15.1 (2019.07.29) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
+## 0.15.1 (2019.07.29)
+Download : [toast-sdk-unity-0.15.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
 
 ### 共通
 
 - iOS 0.16.1 framework適用
 
-## 0.15.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
+## 0.15.0 (2019.07.23)
+Download : [toast-sdk-unity-0.15.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
 
 ### TOAST IAP
 
@@ -162,7 +181,8 @@
 
 - ActivedPurchases -> ActivatedPurchses
 
-## 0.14.0 (2019.07.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
+## 0.14.0 (2019.07.02)
+Download : [toast-sdk-unity-0.14.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
 
 ### TOAST Log & Crash
 
@@ -178,7 +198,8 @@
 
 - ActivedPurchases追加
 
-## 0.13.1 (2019.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
+## 0.13.1 (2019.03.26)
+Download : [toast-sdk-unity-0.13.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
 
 ### TOAST Log & Crash
 
@@ -192,7 +213,8 @@
 
 - Android 上でクラッシュログの送信時に空の文字列がある場合、SDK の例外ログが送信される問題を解決。
 
-## 0.13.0 (2019.02.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
+## 0.13.0 (2019.02.26)
+Download : [toast-sdk-unity-0.13.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
 
 ### TOAST Log & Crash
 
@@ -200,7 +222,8 @@
 
 - クラッシュログをフィルタリングする機能を追加
 
-## 0.12.0 (2019.01.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
+## 0.12.0 (2019.01.08)
+Download : [toast-sdk-unity-0.12.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
 
 ### TOAST IAP
 
@@ -208,7 +231,8 @@
 
 - 新規機能追加
 
-## 0.11.0 (2018.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
+## 0.11.0 (2018.12.27)
+Download : [toast-sdk-unity-0.11.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
 
 ### TOAST Log & Crash
 
@@ -217,7 +241,8 @@
 - Unity で発生した予期せぬ例外のログを自動的に送信する機能を追加
 - SetCrashListener API 追加
 
-## 0.10.0 (2018.11.20) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
+## 0.10.0 (2018.11.20)
+Download : [toast-sdk-unity-0.10.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
 
 ### TOAST Log & Crash
 
@@ -231,7 +256,8 @@
 - Unity パッケージから mainTemplate.gradle 削除
   - mainTemplate.gradle 設定はガイド参照
 
-## 0.9.0 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
+## 0.9.0 (2018.09.04)
+Download : [toast-sdk-unity-0.9.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
 
 ### TOAST Log & Crash
 

--- a/ja/toast-sdk/release-notes-windows.md
+++ b/ja/toast-sdk/release-notes-windows.md
@@ -1,6 +1,7 @@
 ## TOAST > TOAST SDK使用ガイド > リリースノート > Windows C++ 
  
-## 0.9.4.3 (2019.10.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
+## 0.9.4.3 (2019.10.10)
+Download : [toast-sdk-windows-0.9.4.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
  
 ### TOAST Log & Crash 
  
@@ -8,7 +9,8 @@
  
 * x86でpure virtual call / invalid parameterのクラッシュログが残らない問題を修正 
  
-## 0.9.3.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
+## 0.9.3.0 (2019.07.23)
+Download : [toast-sdk-windows-0.9.3.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
  
 ### TOAST Log & Crash 
  
@@ -22,7 +24,8 @@
 	* visual studio 2015 (vc14)バージョンを提供 
 * xpバージョンを提供 
  
-## 0.9.0.12 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
+## 0.9.0.12 (2018.09.04)
+Download : [toast-sdk-windows-0.9.0.12.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
  
 ### TOAST Log & Crash 
  

--- a/ko/toast-sdk/release-notes-unity.md
+++ b/ko/toast-sdk/release-notes-unity.md
@@ -1,6 +1,7 @@
 ## TOAST > TOAST SDK 사용 가이드 > 릴리스 노트 > Unity
 
-## 0.22.0 (2021.04.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
+## 0.22.0 (2021.04.27)
+Download : [toast-sdk-unity-0.22.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
 
 ### 기능 추가
 
@@ -12,7 +13,8 @@
 * Android : 0.25.0
 * iOS : 0.27.2
 
-## 0.21.6 (2021.03.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
+## 0.21.6 (2021.03.23)
+Download : [toast-sdk-unity-0.21.6.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
 
 ### 버그 수정
 
@@ -22,19 +24,22 @@
 
 - iOS : 0.27.2
 
-## 0.21.5 (2021.01.15) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
+## 0.21.5 (2021.01.15)
+Download : [toast-sdk-unity-0.21.5.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
 
 ### plugin version
 
 - Android : 0.25.0
 
-## 0.21.4 (2020.12.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
+## 0.21.4 (2020.12.10)
+Download : [toast-sdk-unity-0.21.4.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
 
 ### plugin version
 
 - Android : 0.24.3
 
-## 0.21.3 (2020.11.24) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
+## 0.21.3 (2020.11.24)
+Download : [toast-sdk-unity-0.21.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
 
 ### plugin version
 
@@ -49,13 +54,15 @@
 
 - Galaxy Store 추가
 
-## 0.21.2 (2020.10.05) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
+## 0.21.2 (2020.10.05)
+Download : [toast-sdk-unity-0.21.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
 
 ### plugin version
 
 - Android : 0.23.2
 
-## 0.21.1 (2020.09.16) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
+## 0.21.1 (2020.09.16)
+Download : [toast-sdk-unity-0.21.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
 
 ### plugin version
 
@@ -66,7 +73,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.3 (2020.07.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
+## 0.20.3 (2020.07.10)
+Download : [toast-sdk-unity-0.20.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
 
 ### plugin version
 
@@ -77,7 +85,8 @@
 
 - InstanceLogger 사용시, 암호화키를 호출하지 않는 버그 수정
 
-## 0.20.2 (2020.07.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
+## 0.20.2 (2020.07.08)
+Download : [toast-sdk-unity-0.20.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
 
 ### plugin version
 
@@ -88,7 +97,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.1 (2020.06.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
+## 0.20.1 (2020.06.23)
+Download : [toast-sdk-unity-0.20.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
 
 ### plugin version
 
@@ -103,7 +113,8 @@
 
 - Windows 환경에서 C++ DLL 의존성 제거
 
-## 0.20.0 (2020.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
+## 0.20.0 (2020.03.26)
+Download : [toast-sdk-unity-0.20.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
 
 ### plugin version
 
@@ -114,19 +125,22 @@
 
 - CrashFilter관련 처리에서 Exception 이슈
 
-## 0.19.1 (2020.01.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
+## 0.19.1 (2020.01.23)
+Download : [toast-sdk-unity-0.19.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
 
 ### 버그 수정
 
 - OnHandleException 콜백 호출 이슈
 
-## 0.19.0 (2019.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
+## 0.19.0 (2019.12.27) [[Download]]()
+Download : [toast-sdk-unity-0.19.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
 
 ### 추가 사항
 
 - Unity Play Services Resolver 적용
 
-## 0.18.0 (2019.12.06) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
+## 0.18.0 (2019.12.06)
+Download : [toast-sdk-unity-0.18.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
 
 ### 공통
 
@@ -134,13 +148,15 @@
 - Android 0.19.4 aar 포함해서 배포
 - Native Plugin (Windows, MacOS) 배포
 
-## 0.17.0 (2019.10.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
+## 0.17.0 (2019.10.02)
+Download : [toast-sdk-unity-0.17.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
 
 ### TOAST IAP
 
 - 구매 요청시 사용자 데이터 설정 기능 추가
 
-## 0.16.0 (2019.08.28) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
+## 0.16.0 (2019.08.28)
+Download : [toast-sdk-unity-0.16.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
 
 ### TOAST IAP
 
@@ -148,13 +164,15 @@
 
 - 소비성 구독 상품 추가
 
-## 0.15.1 (2019.07.29) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
+## 0.15.1 (2019.07.29)
+Download : [toast-sdk-unity-0.15.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
 
 ### 공통
 
 - iOS 0.16.1 framework 적용
 
-## 0.15.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
+## 0.15.0 (2019.07.23)
+Download : [toast-sdk-unity-0.15.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
 
 ### TOAST IAP
 
@@ -162,7 +180,8 @@
 
 - ActivedPurchases -> ActivatedPurchses
 
-## 0.14.0 (2019.07.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
+## 0.14.0 (2019.07.02)
+Download : [toast-sdk-unity-0.14.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
 
 ### TOAST Log & Crash
 
@@ -178,7 +197,8 @@
 
 - ActivedPurchases 추가
 
-## 0.13.1 (2019.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
+## 0.13.1 (2019.03.26)
+Download : [toast-sdk-unity-0.13.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
 
 ### TOAST Log & Crash
 
@@ -192,7 +212,8 @@
 
 - 안드로이드에서 크래시 로그 전송시 빈 문자열이 있는 경우 SDK의 예외 로그가 전송되는 문제 해결
 
-## 0.13.0 (2019.02.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
+## 0.13.0 (2019.02.26)
+Download : [toast-sdk-unity-0.13.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
 
 ### TOAST Log & Crash
 
@@ -200,7 +221,8 @@
 
 - 크래시 로그 필터링 기능 추가
 
-## 0.12.0 (2019.01.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
+## 0.12.0 (2019.01.08)
+Download : [toast-sdk-unity-0.12.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
 
 ### TOAST IAP
 
@@ -208,7 +230,8 @@
 
 - 신규 기능 추가
 
-## 0.11.0 (2018.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
+## 0.11.0 (2018.12.27)
+Download : [toast-sdk-unity-0.11.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
 
 ### TOAST Log & Crash
 
@@ -217,7 +240,8 @@
 - 유니티에서 발생한 예기치 못한 예외에 대한 로그를 자동으로 전송하는 기능 추가
 - SetCrashListener API 추가
 
-## 0.10.0 (2018.11.20) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
+## 0.10.0 (2018.11.20)
+Download : [toast-sdk-unity-0.10.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
 
 ### TOAST Log & Crash
 
@@ -231,7 +255,8 @@
 - 유니티 패키지에서 mainTemplate.gradle 제거
   - mainTemplate.gradle 설정은 가이드 참고
 
-## 0.9.0 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
+## 0.9.0 (2018.09.04)
+Download : [toast-sdk-unity-0.9.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
 
 ### TOAST Log & Crash
 

--- a/ko/toast-sdk/release-notes-windows.md
+++ b/ko/toast-sdk/release-notes-windows.md
@@ -1,5 +1,6 @@
 ## TOAST > TOAST SDK 사용 가이드 > 릴리스 노트 > Windows C++
-## 1.0.0.5 (2021.03.31) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/1.0.0/toast-sdk-windows-1.0.0.5.zip)
+## 1.0.0.5 (2021.03.31)
+Download : [toast-sdk-windows-1.0.0.5.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/1.0.0/toast-sdk-windows-1.0.0.5.zip)
 * 버그 수정
 * 일부 API 인터페이스 수정
 * 사용자 정의 필드 사용시 입력값 검증 
@@ -9,7 +10,8 @@
 	* 샘플 프로젝트 포함
 	
 	
-## 0.9.4.3 (2019.10.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
+## 0.9.4.3 (2019.10.10)
+Download : [toast-sdk-windows-0.9.4.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
 
 ### TOAST Log & Crash
 
@@ -17,7 +19,8 @@
 
 * x86에서 pure virtual call / invalid parameter 크래쉬로그가 남지 않는 현상 처리
 
-## 0.9.3.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
+## 0.9.3.0 (2019.07.23)
+Download : [toast-sdk-windows-0.9.3.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
 
 ### TOAST Log & Crash
 
@@ -31,7 +34,8 @@
 	* visual studio 2015 (vc14) 버전 제공
 * xp 버전 제공 
 
-## 0.9.0.12 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
+## 0.9.0.12 (2018.09.04)
+Download : [toast-sdk-windows-0.9.0.12.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
 
 ### TOAST Log & Crash
 

--- a/zh/toast-sdk/release-notes-unity.md
+++ b/zh/toast-sdk/release-notes-unity.md
@@ -1,6 +1,7 @@
 ## TOAST > User Guide for TOAST SDK > Release Notes > Unity
 
-## 0.22.0 (2021.04.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
+## 0.22.0 (2021.04.27)
+Download : [toast-sdk-unity-0.22.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.22.0/toast-sdk-unity-0.22.0.zip)
 
 ### Added
 
@@ -12,7 +13,8 @@
 * Android : 0.25.0
 * iOS : 0.27.2
 
-## 0.21.6 (2021.03.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
+## 0.21.6 (2021.03.23)
+Download : [toast-sdk-unity-0.21.6.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.6/toast-sdk-unity-0.21.6.zip)
 
 ### Fixed
 
@@ -22,19 +24,22 @@
 
 - iOS : 0.27.2
 
-## 0.21.5 (2021.01.15) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
+## 0.21.5 (2021.01.15)
+Download : [toast-sdk-unity-0.21.5.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.5/toast-sdk-unity-0.21.5.zip)
 
 ### plugin version
 
 - Android : 0.24.4
 
-## 0.21.4 (2020.12.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
+## 0.21.4 (2020.12.10)
+Download : [toast-sdk-unity-0.21.4.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.4/toast-sdk-unity-0.21.4.zip)
 
 ### plugin version
 
 - Android : 0.24.3
 
-## 0.21.3 (2020.11.24) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
+## 0.21.3 (2020.11.24)
+Download : [toast-sdk-unity-0.21.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.3/toast-sdk-unity-0.21.3.zip)
 
 ### plugin version
 
@@ -49,13 +54,15 @@
 
 - Galaxy Store 추가
 
-## 0.21.2 (2020.10.05) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
+## 0.21.2 (2020.10.05)
+Download : [toast-sdk-unity-0.21.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.2/toast-sdk-unity-0.21.2.zip)
 
 ### plugin version
 
 - Android : 0.23.2
 
-## 0.21.1 (2020.09.16) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
+## 0.21.1 (2020.09.16)
+Download : [toast-sdk-unity-0.21.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.21.1/toast-sdk-unity-0.21.1.zip)
 
 ### plugin version
 
@@ -66,7 +73,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.3 (2020.07.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
+## 0.20.3 (2020.07.10)
+Download : [toast-sdk-unity-0.20.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.3/toast-sdk-unity-0.20.3.zip)
 
 ### plugin version
 
@@ -77,7 +85,8 @@
 
 - InstanceLogger 사용시, 암호화키를 호출하지 않는 버그 수정
 
-## 0.20.2 (2020.07.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
+## 0.20.2 (2020.07.08)
+Download : [toast-sdk-unity-0.20.2.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.2/toast-sdk-unity-0.20.2.zip)
 
 ### plugin version
 
@@ -88,7 +97,8 @@
 
 - Native Plugin Version Update
 
-## 0.20.1 (2020.06.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
+## 0.20.1 (2020.06.23)
+Download : [toast-sdk-unity-0.20.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.1/toast-sdk-unity-0.20.1.zip)
 
 ### plugin version
 
@@ -104,7 +114,8 @@
 - Windows 환경에서 C++ DLL 의존성 제거
 
 
-## 0.20.0 (2020.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
+## 0.20.0 (2020.03.26)
+Download : [toast-sdk-unity-0.20.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.20.0/toast-sdk-unity-0.20.0.zip)
 
 ### plugin version
 
@@ -115,19 +126,22 @@
 
 - CrashFilter관련 처리에서 Exception 이슈
 
-## 0.19.1 (2020.01.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
+## 0.19.1 (2020.01.23)
+Download : [toast-sdk-unity-0.19.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.1/toast-sdk-unity-0.19.1.zip)
 
 ### Fixed
 
 - OnHandleException 콜백 호출 이슈
 
-## 0.19.0 (2019.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
+## 0.19.0 (2019.12.27)
+Download : [toast-sdk-unity-0.19.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.19.0/toast-sdk-unity-0.19.0.zip)
 
 ### Added
 
 - Unity Play Services Resolver 적용
 
-## 0.18.0 (2019.12.06) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
+## 0.18.0 (2019.12.06)
+Download : [toast-sdk-unity-0.18.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.18.0/toast-sdk-unity-0.18.0.zip)
 
 ### Common
 
@@ -135,13 +149,15 @@
 - Android 0.19.4 aar 포함해서 배포
 - Native Plugin (Windows, MacOS) 배포
 
-## 0.17.0 (2019.10.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
+## 0.17.0 (2019.10.02)
+Download : [toast-sdk-unity-0.17.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.17.0/toast-sdk-unity-0.17.0.zip)
 
 ### TOAST IAP
 
 - 구매 요청시 사용자 데이터 설정 기능 추가
 
-## 0.16.0 (2019.08.28) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
+## 0.16.0 (2019.08.28)
+Download : [toast-sdk-unity-0.16.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.16.0/toast-sdk-unity-0.16.0.zip)
 
 ### TOAST IAP
 
@@ -149,13 +165,15 @@
 
 - 소비성 구독 상품 추가
 
-## 0.15.1 (2019.07.29) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
+## 0.15.1 (2019.07.29)
+Download : [toast-sdk-unity-0.15.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.1/toast-sdk-unity-0.15.1.zip)
 
 ### Common
 
 - iOS 0.16.1 framework 적용
 
-## 0.15.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
+## 0.15.0 (2019.07.23)
+Download : [toast-sdk-unity-0.15.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.15.0/toast-sdk-unity-0.15.0.zip)
 
 ### TOAST IAP
 
@@ -163,7 +181,8 @@
 
 - ActivedPurchases -> ActivatedPurchses
 
-## 0.14.0 (2019.07.02) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
+## 0.14.0 (2019.07.02)
+Download : [toast-sdk-unity-0.14.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.14.0/toast-sdk-unity-0.14.0.zip)
 
 ### TOAST Log & Crash
 
@@ -179,7 +198,8 @@
 
 - ActivedPurchases 추가
 
-## 0.13.1 (2019.03.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
+## 0.13.1 (2019.03.26)
+Download : [toast-sdk-unity-0.13.1.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.1/toast-sdk-unity-0.13.1.zip)
 
 ### TOAST Log & Crash
 
@@ -193,7 +213,8 @@
 
 - Fixed a issue that sends a unexpected SDK exception when message is empty in Android.
 
-## 0.13.0 (2019.02.26) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
+## 0.13.0 (2019.02.26)
+Download : [toast-sdk-unity-0.13.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.13.0/toast-sdk-unity-0.13.0.zip)
 
 ### TOAST Log & Crash
 
@@ -201,7 +222,8 @@
 
 - Add a feature that filter crash logs
 
-## 0.12.0 (2019.01.08) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
+## 0.12.0 (2019.01.08)
+Download : [toast-sdk-unity-0.12.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.12.0/toast-sdk-unity-0.12.0.zip)
 
 ### TOAST IAP
 
@@ -209,7 +231,8 @@
 
 - Add module
 
-## 0.11.0 (2018.12.27) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
+## 0.11.0 (2018.12.27)
+Download : [toast-sdk-unity-0.11.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.11.0/toast-sdk-unity-0.11.0.zip)
 
 ### TOAST Log & Crash
 
@@ -218,7 +241,8 @@
 - Add a feature that sends automatically unexpected exception logs that occurs in Unity
 - SetCrashListener API
 
-## 0.10.0 (2018.11.20) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
+## 0.10.0 (2018.11.20)
+Download : [toast-sdk-unity-0.10.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.10.0/toast-sdk-unity-0.10.0.zip)
 
 ### TOAST Log & Crash
 
@@ -232,7 +256,8 @@
 - Removed mainTemplate.gradle from Unity Package
   - See guide for setting of mainTemplate.gradle
 
-## 0.9.0 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
+## 0.9.0 (2018.09.04)
+Download : [toast-sdk-unity-0.9.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/unity/0.9.0/toast-sdk-unity-0.9.0.zip)
 
 ### TOAST Log & Crash
 

--- a/zh/toast-sdk/release-notes-windows.md
+++ b/zh/toast-sdk/release-notes-windows.md
@@ -1,6 +1,7 @@
 ## TOAST > User Guide for TOAST SDK > Release Notes > Windows C++
 
-## 0.9.4.3 (2019.10.10) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
+## 0.9.4.3 (2019.10.10)
+Download : [toast-sdk-windows-0.9.4.3.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.4/toast-sdk-windows-0.9.4.3.zip)
 
 ### TOAST Log & Crash
 
@@ -8,7 +9,8 @@
 
 * x86에서 pure virtual call / invalid parameter 크래쉬로그가 남지 않는 현상 처리
 
-## 0.9.3.0 (2019.07.23) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
+## 0.9.3.0 (2019.07.23)
+Download : [toast-sdk-windows-0.9.3.0.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.3/toast-sdk-windows-0.9.3.0.zip)
 
 ### TOAST Log & Crash
 
@@ -22,7 +24,8 @@
 	* visual studio 2015 (vc14) 버전 제공
 * xp 버전 제공 
 
-## 0.9.0.12 (2018.09.04) [[Download]](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
+## 0.9.0.12 (2018.09.04)
+Download : [toast-sdk-windows-0.9.0.12.zip](https://static.toastoven.net/toastcloud/sdk_download/toast/windows/0.9.0/toast-sdk-windows-0.9.0.12.zip)
 
 ### TOAST Log & Crash
 


### PR DESCRIPTION
업무 참조
https://nhnent.dooray.com/project/posts/3006393198978928826

업무 내용
릴리스노트의 버전별 다운로드 링크의 위치를 버전 표기 아래로 변경