### PR TITLE
REPLY 버튼 사용시 안드로이드 버전 안내 추가

### DIFF
--- a/en/toast-sdk/push-android.md
+++ b/en/toast-sdk/push-android.md
@@ -384,6 +384,7 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |

--- a/en/toast-sdk/push-android.md
+++ b/en/toast-sdk/push-android.md
@@ -391,7 +391,7 @@ public class MyApplication extends Application {
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
 
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 
@@ -413,7 +413,7 @@ public class MyApplication extends Application {
 
 #### 그룹
 * 동일한 그룹키를 갖는 알림들이 그룹핑되어 표현됩니다.
-* 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 ### 알림 액션 리스너 등록
 * 사용자가 알림의 버튼 혹은 답장 전송 버튼 클릭시 알림 액션 리스너로 통지합니다.

--- a/en/toast-sdk/push-android.md
+++ b/en/toast-sdk/push-android.md
@@ -384,13 +384,14 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |
 | URL 열기 (OPEN_URL) | URL로 이동<br/>(웹 URL 주소 혹은 앱 커스텀 스킴 실행) | PushAction.ActionType.OPEN_URL |
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
+
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 

--- a/ja/toast-sdk/push-android.md
+++ b/ja/toast-sdk/push-android.md
@@ -392,7 +392,7 @@ public class MyApplication extends Application {
 | 返信 (REPLY) | 通知から返信を送ります。 | PushAction.ActionType.REPLY |
 | 通知削除 (DISMISS) | 現在の通知を削除します。 | PushAction.ActionType.DISMISS |
 
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 > ボタンは最大3個までサポートします。
 
@@ -414,7 +414,7 @@ public class MyApplication extends Application {
 
 #### グループ
 * 同じキーの通知を1つにまとめます。
-* Android 7.0(APIレベル24)以上でのみ使用可能です。
+* 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 ### 通知アクションリスナー登録
 * ユーザーが通知のボタン、または返信送信ボタンをクリックすると、通知アクション リスナーに通知します。

--- a/ja/toast-sdk/push-android.md
+++ b/ja/toast-sdk/push-android.md
@@ -385,13 +385,14 @@ public class MyApplication extends Application {
 ### サポートするリッチメッセージ
 
 #### ボタン
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | タイプ | 機能 | アクション |
 | --- | ------- | --- |
 | アプリを開く (OPEN_APP) | アプリを実行します。 | PushAction.ActionType.OPEN_APP |
 | URLを開く (OPEN_URL) | URLで移動<br/>(ウェブURLアドレスもしくはアプリカスタムスキームを実行) | PushAction.ActionType.OPEN_URL |
 | 返信 (REPLY) | 通知から返信を送ります。 | PushAction.ActionType.REPLY |
 | 通知削除 (DISMISS) | 現在の通知を削除します。 | PushAction.ActionType.DISMISS |
+
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 
 > ボタンは最大3個までサポートします。
 

--- a/ja/toast-sdk/push-android.md
+++ b/ja/toast-sdk/push-android.md
@@ -385,7 +385,7 @@ public class MyApplication extends Application {
 ### サポートするリッチメッセージ
 
 #### ボタン
-
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | タイプ | 機能 | アクション |
 | --- | ------- | --- |
 | アプリを開く (OPEN_APP) | アプリを実行します。 | PushAction.ActionType.OPEN_APP |

--- a/ko/toast-sdk/push-android.md
+++ b/ko/toast-sdk/push-android.md
@@ -384,6 +384,7 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |

--- a/ko/toast-sdk/push-android.md
+++ b/ko/toast-sdk/push-android.md
@@ -391,7 +391,7 @@ public class MyApplication extends Application {
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
 
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 
@@ -413,7 +413,7 @@ public class MyApplication extends Application {
 
 #### 그룹
 * 동일한 그룹키를 갖는 알림들이 그룹핑되어 표현됩니다.
-* 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 ### 알림 액션 리스너 등록
 * 사용자가 알림의 버튼 혹은 답장 전송 버튼 클릭시 알림 액션 리스너로 통지합니다.

--- a/ko/toast-sdk/push-android.md
+++ b/ko/toast-sdk/push-android.md
@@ -384,13 +384,14 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |
 | URL 열기 (OPEN_URL) | URL로 이동<br/>(웹 URL 주소 혹은 앱 커스텀 스킴 실행) | PushAction.ActionType.OPEN_URL |
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
+
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 

--- a/zh/toast-sdk/push-android.md
+++ b/zh/toast-sdk/push-android.md
@@ -384,6 +384,7 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |

--- a/zh/toast-sdk/push-android.md
+++ b/zh/toast-sdk/push-android.md
@@ -391,7 +391,7 @@ public class MyApplication extends Application {
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
 
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 
@@ -413,7 +413,7 @@ public class MyApplication extends Application {
 
 #### 그룹
 * 동일한 그룹키를 갖는 알림들이 그룹핑되어 표현됩니다.
-* 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
+* 안드로이드 7.0(API 레벨 24) 이상부터 사용 가능합니다.
 
 ### 알림 액션 리스너 등록
 * 사용자가 알림의 버튼 혹은 답장 전송 버튼 클릭시 알림 액션 리스너로 통지합니다.

--- a/zh/toast-sdk/push-android.md
+++ b/zh/toast-sdk/push-android.md
@@ -384,13 +384,14 @@ public class MyApplication extends Application {
 ### 지원하는 리치 메시지
 
 #### 버튼
-* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 | 유형 | 기능 | 액션 |
 | --- | ------- | --- |
 | 앱 열기 (OPEN_APP) | 어플리케이션 실행 | PushAction.ActionType.OPEN_APP |
 | URL 열기 (OPEN_URL) | URL로 이동<br/>(웹 URL 주소 혹은 앱 커스텀 스킴 실행) | PushAction.ActionType.OPEN_URL |
 | 답장 (REPLY) | 알림에서 답장 전송 | PushAction.ActionType.REPLY |
 | 취소 (DISMISS) | 현재 알림 취소 | PushAction.ActionType.DISMISS |
+
+* 답장 (REPLY) 버튼은 안드로이드 7.0(API 레벨 24) 이상에서만 사용가능합니다.
 
 > 버튼은 메시지당 최대 3개까지 지원합니다.
 


### PR DESCRIPTION
## 업무 참조
https://nhnent.dooray.com/project/posts/3038300166848029836

## 내용
REPLY 버튼은 안드로이드 7.0 이상에서 사용이 가능함을 안내하는 문구 추가