### PR TITLE
TOAST SDK Push iOS 가이드 링크 수정

### DIFF
--- a/en/toast-sdk/push-ios.md
+++ b/en/toast-sdk/push-ios.md
@@ -454,7 +454,7 @@ agreement.allowNightAdvertisements = YES;   // Agree to receive night-time adver
 
 ## User Tag
 
-* The [User Tag](https://https://docs.toast.com/en/Notification/Push/en/console-guide/#tags) feature binds multiple user IDs in one tag and uses it to send messages.
+* The [User Tag](https://docs.toast.com/en/Notification/Push/en/console-guide/#tags) feature binds multiple user IDs in one tag and uses it to send messages.
 * It operates based on the tag ID (8-character string) rather than the tag name, and the tag ID can be created and checked in the Console > Tag menu.
 
 ### Specification for User Tag Setting API

--- a/ja/toast-sdk/push-ios.md
+++ b/ja/toast-sdk/push-ios.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 1. [TOAST SDK](./getting-started-ios)を設置します。
-2. [TOASTコンソール](https://console.cloud.toast.com)で [Notification \> Pushを有効化](http://docs.toast.com/ko/Notification/Push/ko/console-guide/)します。
+2. [TOASTコンソール](https://console.cloud.toast.com)で [Notification \> Pushを有効化](http://docs.toast.com/ja/Notification/Push/ja/console-guide/)します。
 3. PushでAppKeyを確認します。
 
 ## APNSガイド

--- a/ja/toast-sdk/push-ios.md
+++ b/ja/toast-sdk/push-ios.md
@@ -452,7 +452,7 @@ agreement.allowNightAdvertisements = YES;   // 夜間広報性通知メッセー
 
 ## ユーザー·タグ
 
-* [ユーザー·タグ](https://docs.toast.com/ko/Notification/Push/ko/console-guide/#_16)能は、複数のユーザー IDをひとつのタグで結びつけ、それを活用してメッセージを送信することができます。
+* [ユーザー·タグ](https://docs.toast.com/ja/Notification/Push/ja/console-guide/#_16)能は、複数のユーザー IDをひとつのタグで結びつけ、それを活用してメッセージを送信することができます。
 * タグ名ではなく、タグID(8桁の文字列)に基づいて動作し、タグIDはコンソール > タグメニューから作成・確認できます。
 
 ### ユーザー·タグ設定API

--- a/zh/toast-sdk/push-ios.md
+++ b/zh/toast-sdk/push-ios.md
@@ -454,7 +454,7 @@ agreement.allowNightAdvertisements = YES;   // 야간 홍보성 알림 메시지
 
 ## 사용자 태그
 
-* [사용자 태그](https://docs.toast.com/ko/Notification/Push/ko/console-guide/#_16) 기능은 여러 사용자 아이디를 하나의 태그로 묶고 이를 활용하여 메시지 발송이 가능합니다.
+* [사용자 태그](https://docs.toast.com/zh/Notification/Push/zh/console-guide/#tags) 기능은 여러 사용자 아이디를 하나의 태그로 묶고 이를 활용하여 메시지 발송이 가능합니다.
 * 태그명이 아닌 태그 아이디(8자리 문자열)를 기반으로 동작하며, 태그 아이디는 콘솔 > 태그 메뉴에서 생성 및 확인 가능합니다.
 
 ### 사용자 태그 설정 API 명세

--- a/zh/toast-sdk/push-ios.md
+++ b/zh/toast-sdk/push-ios.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 1. [TOAST SDK](./getting-started-ios)를 설치합니다.
-2. [TOAST 콘솔](https://console.cloud.toast.com)에서 [Notification \> Push를 활성화](http://docs.toast.com/ko/Notification/Push/ko/console-guide/)합니다.
+2. [TOAST 콘솔](https://console.cloud.toast.com)에서 [Notification \> Push를 활성화](http://docs.toast.com/zh/Notification/Push/zh/console-guide/)합니다.
 3. Push에서 AppKey를 확인합니다.
 
 ## APNS 가이드


### PR DESCRIPTION
- QA 업무 : https://nhnent.dooray.com/project/posts/3148565471268803590
해당 업무를 참고하여 영문 가이드의 User Tag 링크를 수정했습니다. 
- 각 언어별 가이드에서 한국어 버전의 콘솔 링크를 해당 언어 버전의 콘솔 가이드 링크로 수정했습니다. (android와 동일하게 변경)