### PR TITLE
TOAST -> NHN Cloud 명칭 변경

### DIFF
--- a/ja/toast-sdk/push-android.md
+++ b/ja/toast-sdk/push-android.md
@@ -29,7 +29,7 @@ dependencies {
 ```
 
 ### ADM
-* TOAST ADM Pushを使用するために、以下のようにbuild.gradleに依存関係を追加します。
+* NHN Cloud ADM Pushを使用するために、以下のようにbuild.gradleに依存関係を追加します。
 
 ```groovy
 repositories {


### PR DESCRIPTION
- 일본어 번역하면서 명칭이 잘못된 부분을 수정합니다.(TOAST -> NHN Cloud)