### PR TITLE
문서 내 태그 링크 변경, IAP 구독 내용 업데이트

### DIFF
--- a/en/toast-sdk/iap-ios.md
+++ b/en/toast-sdk/iap-ios.md
@@ -373,43 +373,33 @@ typedef NS_ENUM(NSInteger, NHNCloudProductType) {
 }
 ```
 
-## Provide Page for Subscription Products
+## 구독 상품 관리 페이지 제공 방법
 
-* For auto-renewable subscription products, users must be provided with a subscription management page.
-> [Apple Guide](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW19)
+* 자동 갱신형 구독 상품을 사용할 경우 사용자에게 구독 관리 페이지를 제공해야 합니다.
+> [Apple Guide](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing?language=objc)
 
-* Without configuring a separate UI, call URL as below to display subscription management page.
+* 별도의 UI를 구성하지 않고 아래 URL을 호출해 구독 관리 페이지를 표시해야 합니다.
 
-### Connect to Subscription Management Page on Safari
 ```
-https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
+https://apps.apple.com/account/subscriptions
+itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscription
 ```
-```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
-```
-#### Management page on Safari is called in the following order:
-1. Safari Opens
-2. Popup Shows: Want to open in iTunes Store?
-3. iTunes Store Opens
-4. Connected to subscription management page on a popup
 
->  `Safari` appears for Return to Previous App on top left on an iOS Device.
-
-
-### Connect to Subscription Management Page on Scheme
-```
-itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
-```
+### 구독 관리 페이지 연결 방법
 
 ```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://apps.apple.com/account/subscriptions"] options: @{} completionHandler:nil];
 ```
 
-#### Management page on Scheme is called in the following order:
-1. Subscription management page of App Store is directly connected with App-to-App call.
+또는
 
->  `Service App` appears for Return to Previous App on top left on an iOS device.
+```objc
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"] options: @{} completionHandler:nil];
+```
 
+App Store의 구독 관리 페이지로 연결됩니다.
+
+> iOS 기기의 왼쪽 상단의 이전 앱으로 돌아가기에 `Service App`이 나타납니다.
 
 ## Remain Compatible with (old) IAP SDK
 

--- a/en/toast-sdk/push-ios.md
+++ b/en/toast-sdk/push-ios.md
@@ -344,7 +344,7 @@ agreement.allowNightAdvertisements = YES;   // Agree to receive night-time adver
 * `Received metrics collection is supported in iOS 10.0+ or higher.`
 * Received metrics are automatically collected by the NHN Cloud Push SDK that was added to the Notification Service Extension.
 * To collect received metrics, you need to implement Notification Service Extension that inherits and implements NHNCloudPushServiceExtension in the user application. (Refer to the [Notification Service Extension](./push-ios/#notification-service-extension) section below for how to add the Notification Service Extension)
-* To enable the collection of received metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) in the Notification Service Extension constructor or **extension's info.plist file**.
+* To enable the collection of received metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) in the Notification Service Extension constructor or **extension's info.plist file**.
 
 #### Example of received metrics collection setting through initialization
 
@@ -395,7 +395,7 @@ agreement.allowNightAdvertisements = YES;   // Agree to receive night-time adver
 ### Opened Metric Collection Setting
 
 * Opened metrics are automatically collected from the NHN Cloud Push SDK that was added to the application.
-* To enable the collection of opened metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) or **application's info.plist file**.
+* To enable the collection of opened metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) or **application's info.plist file**.
 
 #### Example of opened metrics collection setting through info.plist definition
 
@@ -582,7 +582,7 @@ NSMutableSet<NSString *> *tagIDs = [NSMutableSet set];
 
 ### Initialization
 
-* VoIP function is available only when [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) has been performed.
+* VoIP function is available only when [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) has been performed.
 * The VoIP function is separated as a submodule of the NHN Cloud Push SDK.
 
 ### Delegate Setting

--- a/ja/toast-sdk/iap-ios.md
+++ b/ja/toast-sdk/iap-ios.md
@@ -372,43 +372,33 @@ typedef NS_ENUM(NSInteger, NHNCloudProductType) {
 }
 ```
 
-## 購読商品管理ページの提供方法
+## 구독 상품 관리 페이지 제공 방법
 
-* 自動更新型購読商品を使用する場合、ユーザーに購読管理ページを提供する必要があります。
-> [Apple Guide](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW19)
+* 자동 갱신형 구독 상품을 사용할 경우 사용자에게 구독 관리 페이지를 제공해야 합니다.
+> [Apple Guide](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing?language=objc)
 
-* 別途のUIを構成せず、下記URLを呼び出して購読管理ページを表示する必要があります。
+* 별도의 UI를 구성하지 않고 아래 URL을 호출해 구독 관리 페이지를 표시해야 합니다.
 
-### Safariで購読管理ページに接続する方法
 ```
-https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
+https://apps.apple.com/account/subscriptions
+itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscription
 ```
-```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
-```
-#### Safariで管理ページを呼び出す時は、次のような順序で管理ページが表示されます。
-1. Safari Open
-2. Popup表示：itunse Storeで開きますか？
-3. iTunse Store Open
-4. Popupで購読管理ページに接続
 
-> iOS端末左上の、以前のアプリに戻るに`Safari`が表示されます。
-
-
-### Schemeから購読管理ページに接続する方法
-```
-itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
-```
+### 구독 관리 페이지 연결 방법
 
 ```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://apps.apple.com/account/subscriptions"] options: @{} completionHandler:nil];
 ```
 
-#### Schemeから管理ページを呼び出す時は、次のような順序で管理ページが表示されます。
-1. App Storeの購読管理ページがApp To App呼び出しですぐに接続されます。
+또는
 
-> iOS端末左上の、以前のアプリに戻るに`Service App`が表示されます。
+```objc
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"] options: @{} completionHandler:nil];
+```
 
+App Store의 구독 관리 페이지로 연결됩니다.
+
+> iOS 기기의 왼쪽 상단의 이전 앱으로 돌아가기에 `Service App`이 나타납니다.
 
 ## (旧)IAP SDK互換性維持
 

--- a/ja/toast-sdk/push-ios.md
+++ b/ja/toast-sdk/push-ios.md
@@ -342,7 +342,7 @@ agreement.allowNightAdvertisements = YES;   // 夜間広報性通知メッセー
 * `受信指標の収集は、iOS 10.0+以上からサポートします。`
 * 受信指標は、Notification Service Extensionに追加したNHN Cloud Push SDKで自動的に収集されます。
 * 受信指標を収集には、ユーザーアプリケーションにNHNCloudPushServiceExtensionを継承するNotification Service Extensionを実装しなければなりません。(Notification Service Extension追加方法は、 [Notification Service Extension](./push-ios/#notification-service-extension)セクション参照)
-* Notification Service Extensionの生成者で、[NHN Cloud Push SDK初期化](./push-ios/#nhncloud-push-sdk)、あるいは**エクステンションのinfo.plistファイル**にAppKeyが定義されていないと、受信指標の収集ができません。
+* Notification Service Extensionの生成者で、[NHN Cloud Push SDK初期化](./push-ios/#nhn-cloud-push-sdk)、あるいは**エクステンションのinfo.plistファイル**にAppKeyが定義されていないと、受信指標の収集ができません。
 
 #### 初期化による受信指標収集の設定例
 
@@ -393,7 +393,7 @@ agreement.allowNightAdvertisements = YES;   // 夜間広報性通知メッセー
 ### 実行(Opened)指標収集設定
 
 * 実行指標は、アプリケーションに追加したNHN Cloud Push SDKから自動的に収集されます。
-* [NHN Cloud Push SDK 초기화](./push-ios/#nhncloud-push-sdk)、あるいは**アプリケーションのinfo.plistファイル**にAppKeyが定義されている場合、実行指標の収集が可能です。
+* [NHN Cloud Push SDK 초기화](./push-ios/#nhn-cloud-push-sdk)、あるいは**アプリケーションのinfo.plistファイル**にAppKeyが定義されている場合、実行指標の収集が可能です。
 
 #### info.plist定義による受信指標収集の設定例
 
@@ -579,7 +579,7 @@ NSMutableSet<NSString *> *tagIDs = [NSMutableSet set];
 
 ### 初期化
 
-* VoIP機能は[NHN Cloud Push SDK 初期化](./push-ios/#toast-push-sdk)がされていなければ使用できません。
+* VoIP機能は[NHN Cloud Push SDK 初期化](./push-ios/#nhn-cloud-push-sdk)がされていなければ使用できません。
 * VoIP機能はNHN Cloud Push SDKのサブモジュールで別途分離されています。
 
 ### Delegate設定

--- a/ko/toast-sdk/iap-ios.md
+++ b/ko/toast-sdk/iap-ios.md
@@ -376,40 +376,30 @@ typedef NS_ENUM(NSInteger, NHNCloudProductType) {
 ## 구독 상품 관리 페이지 제공 방법
 
 * 자동 갱신형 구독 상품을 사용할 경우 사용자에게 구독 관리 페이지를 제공해야 합니다.
-> [Apple Guide](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW19)
+> [Apple Guide](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing?language=objc)
 
 * 별도의 UI를 구성하지 않고 아래 URL을 호출해 구독 관리 페이지를 표시해야 합니다.
 
-### Safari를 통한 구독 관리 페이지 연결 방법
 ```
-https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
+https://apps.apple.com/account/subscriptions
+itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscription
 ```
-```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
-```
-#### Safari를 통해 관리 페이지를 호출할 때는 다음과 같은 순서로 관리 페이지가 표시됩니다.
-1. Safari Open
-2. Popup 노출 : itunse Store에서 열겠습니까?
-3. iTunse Store Open
-4. Popup으로 구독 관리 페이지 연결
 
-> iOS 기기의 왼쪽 상단의 이전 앱으로 돌아가기에 `Safari`가 나타납니다.
-
-
-### Scheme을 통한 구독 관리 페이지 연결 방법
-```
-itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
-```
+### 구독 관리 페이지 연결 방법
 
 ```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://apps.apple.com/account/subscriptions"] options: @{} completionHandler:nil];
 ```
 
-#### Scheme을 통해 관리 페이지를 호출할 때는 다음과 같은 순서로 관리 페이지가 표사됩니다.
-1. App Store의 구독 관리 페이지가 App To App 호출로 바로 연결됩니다.
+또는
+
+```objc
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"] options: @{} completionHandler:nil];
+```
+
+App Store의 구독 관리 페이지로 연결됩니다.
 
 > iOS 기기의 왼쪽 상단의 이전 앱으로 돌아가기에 `Service App`이 나타납니다.
-
 
 ## (구)IAP SDK 호환성 유지
 

--- a/ko/toast-sdk/push-ios.md
+++ b/ko/toast-sdk/push-ios.md
@@ -344,7 +344,7 @@ agreement.allowNightAdvertisements = YES;   // 야간 홍보성 알림 메시지
 * `수신 지표 수집은 iOS 10.0+ 이상부터 지원합니다.`
 * 수신 지표는 Notification Service Extension에 추가한 NHN Cloud Push SDK 에서 자동으로 수집됩니다.
 * 수신 지표 수집을 위해서는 사용자 어플리케이션에 NHNCloudPushServiceExtension를 상속 구현하는 Notification Service Extension을 구현해야 합니다. (Notification Service Extension 추가 방법은 아래 [Notification Service Extension](./push-ios/#notification-service-extension) 섹션 참고)
-* Notification Service Extension 생성자에서 [NHN Cloud Push SDK 초기화](./push-ios/#nhncloud-push-sdk) 혹은 **익스텐션의 info.plist 파일**에 앱키가 정의되어 있어야 수신 지표 수집이 가능합니다.
+* Notification Service Extension 생성자에서 [NHN Cloud Push SDK 초기화](./push-ios/#nhn-cloud-push-sdk) 혹은 **익스텐션의 info.plist 파일**에 앱키가 정의되어 있어야 수신 지표 수집이 가능합니다.
 
 #### 초기화를 통한 수신 지표 수집 설정 예
 
@@ -395,7 +395,7 @@ agreement.allowNightAdvertisements = YES;   // 야간 홍보성 알림 메시지
 ### 실행(Opened) 지표 수집 설정
 
 * 실행 지표는 어플리케이션에 추가한 NHN Cloud Push SDK 에서 자동으로 수집됩니다.
-* [NHN Cloud Push SDK 초기화](./push-ios/#nhncloud-push-sdk) 혹은 **어플리케이션의 info.plist 파일**에 앱키가 정의되어 있어야 실행 지표 수집이 가능합니다.
+* [NHN Cloud Push SDK 초기화](./push-ios/#nhn-cloud-push-sdk) 혹은 **어플리케이션의 info.plist 파일**에 앱키가 정의되어 있어야 실행 지표 수집이 가능합니다.
 
 #### info.plist 정의를 통한 수신 지표 수집 설정 예
 
@@ -582,7 +582,7 @@ NSMutableSet<NSString *> *tagIDs = [NSMutableSet set];
 
 ### 초기화
 
-* VoIP 기능은 [NHN Cloud Push SDK 초기화](./push-ios/#toast-push-sdk)가 되어 있어야 사용가능합니다.
+* VoIP 기능은 [NHN Cloud Push SDK 초기화](./push-ios/#nhn-cloud-push-sdk)가 되어 있어야 사용가능합니다.
 * VoIP 기능은 NHN Cloud Push SDK의 서브모듈로 별도 분리되어 있습니다.
 
 ### Delegate 설정

--- a/zh/toast-sdk/iap-ios.md
+++ b/zh/toast-sdk/iap-ios.md
@@ -373,43 +373,33 @@ typedef NS_ENUM(NSInteger, NHNCloudProductType) {
 }
 ```
 
-## Provide Page for Subscription Products
+## 구독 상품 관리 페이지 제공 방법
 
-* For auto-renewable subscription products, users must be provided with a subscription management page.
-> [Apple Guide](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW19)
+* 자동 갱신형 구독 상품을 사용할 경우 사용자에게 구독 관리 페이지를 제공해야 합니다.
+> [Apple Guide](https://developer.apple.com/documentation/storekit/in-app_purchase/original_api_for_in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing?language=objc)
 
-* Without configuring a separate UI, call URL as below to display subscription management page.
+* 별도의 UI를 구성하지 않고 아래 URL을 호출해 구독 관리 페이지를 표시해야 합니다.
 
-### Connect to Subscription Management Page on Safari
 ```
-https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
+https://apps.apple.com/account/subscriptions
+itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscription
 ```
-```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
-```
-#### Management page on Safari is called in the following order:
-1. Safari Opens
-2. Popup Shows: Want to open in iTunes Store?
-3. iTunes Store Opens
-4. Connected to subscription management page on a popup
 
->  `Safari` appears for Return to Previous App on top left on an iOS Device.
-
-
-### Connect to Subscription Management Page on Scheme
-```
-itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
-```
+### 구독 관리 페이지 연결 방법
 
 ```objc
-[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"]];
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://apps.apple.com/account/subscriptions"] options: @{} completionHandler:nil];
 ```
 
-#### Management page on Scheme is called in the following order:
-1. Subscription management page of App Store is directly connected with App-to-App call.
+또는
 
->  `Service App` appears for Return to Previous App on top left on an iOS device.
+```objc
+[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"itms-apps://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions"] options: @{} completionHandler:nil];
+```
 
+App Store의 구독 관리 페이지로 연결됩니다.
+
+> iOS 기기의 왼쪽 상단의 이전 앱으로 돌아가기에 `Service App`이 나타납니다.
 
 ## Remain Compatible with (old) IAP SDK
 

--- a/zh/toast-sdk/push-ios.md
+++ b/zh/toast-sdk/push-ios.md
@@ -344,7 +344,7 @@ agreement.allowNightAdvertisements = YES;   // Agree to receive night-time adver
 * `Received metrics collection is supported in iOS 10.0+ or higher.`
 * Received metrics are automatically collected by the NHN Cloud Push SDK that was added to the Notification Service Extension.
 * To collect received metrics, you need to implement Notification Service Extension that inherits and implements NHNCloudPushServiceExtension in the user application. (Refer to the [Notification Service Extension](./push-ios/#notification-service-extension) section below for how to add the Notification Service Extension)
-* To enable the collection of received metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) in the Notification Service Extension constructor or **extension's info.plist file**.
+* To enable the collection of received metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) in the Notification Service Extension constructor or **extension's info.plist file**.
 
 #### Example of received metrics collection setting through initialization
 
@@ -395,7 +395,7 @@ agreement.allowNightAdvertisements = YES;   // Agree to receive night-time adver
 ### Opened Metric Collection Setting
 
 * Opened metrics are automatically collected from the NHN Cloud Push SDK that was added to the application.
-* To enable the collection of opened metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) or **application's info.plist file**.
+* To enable the collection of opened metrics, an Appkey must be defined in the [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) or **application's info.plist file**.
 
 #### Example of opened metrics collection setting through info.plist definition
 
@@ -582,7 +582,7 @@ NSMutableSet<NSString *> *tagIDs = [NSMutableSet set];
 
 ### Initialization
 
-* VoIP function is available only when [NHN Cloud Push SDK initialization](./push-ios/#toast-push-sdk) has been performed.
+* VoIP function is available only when [NHN Cloud Push SDK initialization](./push-ios/#nhn-cloud-push-sdk) has been performed.
 * The VoIP function is separated as a submodule of the NHN Cloud Push SDK.
 
 ### Delegate Setting


### PR DESCRIPTION
# 변경 내용

## push-ios
* 마크다운 문서 내 태그링크 수정

## iap-ios
* 구독 상품 관리페이지 제공 방법 내용 변경
* 아래 구독상품 관리페이지 진입 URL 중 https scheme로만 동작이 가능한 것, itms-app scheme으로만 동작이 가능한 것을 확인했습니다.  Safari를 통한 구독 관리 페이지 연결방법이 실제 동작과 달라 가이드 내용을 변경합니다. (앱 내에서 -[UIApplication openURL:options:completionHandler]  를 통해 open 하는 경우 Safari를 거치지 않고 바로 앱스토어 구독페이지로 이동)
    * ❌  https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions  
    * ⭕  itms-app://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions
    * ⭕  https://apps.apple.com/account/subscriptions
    * ❌  itms-app://apps.apple.com/account/subscriptions
   
* -[UIApplication openURL:] 이 deprecated 되어 예제코드를 -[UIApplication openURL:options:completionHandler] 로 변경합니다.