### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/ja/nhncloud-sdk/getting-started-unity.md
+++ b/ja/nhncloud-sdk/getting-started-unity.md
@@ -149,6 +149,8 @@ allprojects {
 }
 ```
 
+<a id="when-an-ndk-related-error-occurs"></a>
+
 #### NDK関連エラー発生時
 - Gradleを設定してビルドを行うと、下記のようなエラーが発生することがあります。
 > No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-haiku-4-5` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-040002` |
| Scope | 50 doc(s) scanned · 1 file(s) changed · 48 unchanged · 1 skipped(error) |
| Self-verify | ⚠️ 2 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/70/ |
| Generated | 2026-06-15T05:41:06 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-040002`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Ftree%2Fpre-align%2Ffix-headings-20260615-040002&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fpull%2F348&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ja/nhncloud-sdk/getting-started-unity.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 2 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/nhncloud-sdk/getting-started-unity.md`:
  - extra_in_target (ko#None/ja#18)
  - missing_in_target (ko#23/ja#None)

</details>

<details><summary>변경 없이 건너뛴 문서 (48) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `architecture-icon.md`
- `console-guide.md`
- `console-user-guide.md`
- `nhncloud-sdk/creditcard-recognizer-android.md`
- `nhncloud-sdk/creditcard-recognizer-ios.md`
- `nhncloud-sdk/getting-started-android.md`
- `nhncloud-sdk/getting-started-ios.md`
- `nhncloud-sdk/getting-started-windows.md`
- `nhncloud-sdk/iap-ios.md`
- `nhncloud-sdk/iap-unity.md`
- `nhncloud-sdk/idcard-recognizer-android.md`
- `nhncloud-sdk/idcard-recognizer-ios.md`
- `nhncloud-sdk/log-collector-android.md`
- `nhncloud-sdk/log-collector-ios.md`
- `nhncloud-sdk/log-collector-ndk.md`
- `nhncloud-sdk/log-collector-reserved-fields.md`
- `nhncloud-sdk/log-collector-unity.md`
- `nhncloud-sdk/log-collector-windows.md`
- `nhncloud-sdk/overview.md`
- `nhncloud-sdk/push-android.md`
- `nhncloud-sdk/push-ios.md`
- `nhncloud-sdk/release-notes-android.md`
- `nhncloud-sdk/release-notes-ios.md`
- `nhncloud-sdk/release-notes-unity.md`
- `nhncloud-sdk/release-notes-windows.md`
- `nhncloud-sdk/symbol-uploader-android.md`
- `old/Getting Started.md`
- `old/Overview.md`
- `old/README.md`
- `old/Release Notes.md`
- `overview.md`
- `public-api/appkey.md`
- `public-api/partner-api.md`
- `public-api/project-integrated-appkey.md`
- `public-api/release-notes.md`
- `public-api/service-api.md`
- `public-api/supported-authentication-methods.md`
- `public-api/user-access-key-token.md`
- `public-api/user-access-key.md`
- `region-guide.md`
- `resource-policy.md`
- `security-policy.md`
- `terraform-guide.md`
- `toast-sdk-logncrash/android.md`
- `toast-sdk-logncrash/ios.md`
- `toast-sdk-logncrash/unity.md`
- `trademark-guide/brand-overview.md`
- `trademark-guide/powered-by-nhncloud-guide.md`

</details>

<details><summary>⚠ 처리 오류/건너뜀 (1) — 닫히지 않은 코드펜스 등으로 정렬을 건너뛴 문서 (검토·소스 수정 필요)</summary>

- ja/nhncloud-sdk/iap-android.md: 닫히지 않은 코드펜스(ja) — 헤딩이 가려져 잘못된 stub을 만들 수 있어 건너뜀 (소스 문서의 ``` 짝을 먼저 고치세요)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/TOAST-Cloud`