### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/public-api/framework-api.md
+++ b/en/public-api/framework-api.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=eddd49bbcebe -->
+
 # Framework API
 
 **NHN Cloud > Public API User Guide > Framework API**

--- a/en/toast-sdk-logncrash/android.md
+++ b/en/toast-sdk-logncrash/android.md
@@ -1,1 +1,117 @@
+<!-- pre-align:aligned sig=522c249f15a2 -->
+
 ## Analytics > Log & Crash Search > TOAST SDK Guide > Android
+<a id="section-1"></a>
+
+## Prerequisites
+
+<!-- TODO: translate body -->
+
+<a id="section-2"></a>
+
+## Component SDKs
+
+<!-- TODO: translate body -->
+
+<a id="section-3"></a>
+
+## Getting Started Android SDK
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1"></a>
+
+### Environments
+
+<!-- TODO: translate body -->
+
+<a id="section-3-2"></a>
+
+### Add TOAST SDK to Your Project
+
+<!-- TODO: translate body -->
+
+<a id="section-3-3"></a>
+
+### Initialize TOAST SDK
+
+<!-- TODO: translate body -->
+
+<a id="section-4"></a>
+
+## Log Collector
+
+<!-- TODO: translate body -->
+
+<a id="section-4-1"></a>
+
+### Initialize
+
+<!-- TODO: translate body -->
+
+<a id="section-4-2"></a>
+
+### Send Log
+
+<!-- TODO: translate body -->
+
+<a id="section-4-3"></a>
+
+### Set UserID
+
+<!-- TODO: translate body -->
+
+<a id="section-4-4"></a>
+
+### Set User Field
+
+<!-- TODO: translate body -->
+
+<a id="section-4-5"></a>
+
+### Log Callback
+
+<!-- TODO: translate body -->
+
+<a id="section-5"></a>
+
+## Crash Reporter
+
+<!-- TODO: translate body -->
+
+<a id="section-5-1"></a>
+
+### Initialize
+
+<!-- TODO: translate body -->
+
+<a id="section-5-2"></a>
+
+### Send Handled Exception
+
+<!-- TODO: translate body -->
+
+<a id="section-5-2-1"></a>
+
+#### Using
+
+<!-- TODO: translate body -->
+
+<a id="section-5-3"></a>
+
+### Set User Field
+
+<!-- TODO: translate body -->
+
+<a id="section-5-4"></a>
+
+### Set Data Adapter
+
+<!-- TODO: translate body -->
+
+<a id="section-5-5"></a>
+
+### Crash Callback
+
+<!-- TODO: translate body -->
+

--- a/en/user-guide.md
+++ b/en/user-guide.md
@@ -235,41 +235,43 @@ The authentication and management policy of each payment method goes as follows:
 #### Complete Registration of Payment Methods
 - If your payment method is successfully registered, you can see it on the Payment Method screen.
 
-<a id="bank-transfers"></a>
+<a id="how-to-register-payment-methods-1"></a>
 
 ### Bank Transfers
-<a id="select-payment-methods-3"></a>
+<a id="authenticate-public-key-certificates"></a>
 
 #### Select Payment Methods
 - Provided only for business members.
 - Go to **Payment Methods** and click **Change Payment Methods**.
 - On the **Register Auto Payment Methods** page, click **Bank Transfer**.
 
-<a id="enter-account-information"></a>
+<a id="complete-registration-of-payment-methods-2"></a>
 
 #### Enter Account Information
 - Enter your account information.
 
-<a id="authenticate-public-key-certificates"></a>
+<a id="select-payment-methods-4"></a>
 
 #### Authenticate Public Key Certificates
 - For s personal account, select a personal Public Key Certificate for authentication.
 - For a corporate account, select a Public Key Certificate registered with the same business information on its account for authentication.
 
-<a id="complete-registration-of-payment-methods-2"></a>
+<a id="complete-registration-of-payment-methods-3"></a>
 
 #### Complete Registration of Payment Methods 
 - If your payment method is successfully registered, you can see it on the Payment Method screen.
 
 **NHN Cloud Japan **
+<a id="bank-transfers"></a>
+
 ### Credit Cards 
-<a id="select-payment-methods-4"></a>
+<a id="select-payment-methods-3"></a>
 
 #### Select Payment Methods 
 - Go to **Payment Methods** and click **Change Payment Methods**.
 - On the **Register Auto Payment Methods** page, enter **Credit Card Information**(card number, valid period, card holder's name, and security code).
 
-<a id="complete-registration-of-payment-methods-3"></a>
+<a id="enter-account-information"></a>
 
 #### Complete Registration of Payment Methods
 - If your payment method is successfully registered, you can see it on the Payment Method screen.

--- a/ja/nhncloud-sdk/getting-started-unity.md
+++ b/ja/nhncloud-sdk/getting-started-unity.md
@@ -149,6 +149,8 @@ allprojects {
 }
 ```
 
+<a id="when-an-ndk-related-error-occurs"></a>
+
 #### NDK関連エラー発生時
 - Gradleを設定してビルドを行うと、下記のようなエラーが発生することがあります。
 > No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android

--- a/ja/public-api/framework-api.md
+++ b/ja/public-api/framework-api.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=eddd49bbcebe -->
+
 # フレームワークAPI
 
 **NHN Cloud > Public API使用ガイド > フレームワークAPI**
@@ -4289,11 +4291,15 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 GET /v1/organizations
 ```
 
-##### 필요 권한
+##### 必要権限
 
 <!-- TODO: translate body -->
 
-##### 必要な権限
+**필요 권한**
+
+<!-- TODO: translate body -->
+
+**必要な権限**
 会員であれば特定の権限なしで呼び出し可能なAPIです。
 
 **[Query Parameter]**
@@ -4411,11 +4417,15 @@ GET /v1/organizations
 > POST /v1/organizations
 自身の組織を追加するAPIです。
 
-##### 필요 권한
+##### 必要権限
 
 <!-- TODO: translate body -->
 
-##### 必要な権限
+**필요 권한**
+
+<!-- TODO: translate body -->
+
+**必要な権限**
 会員であれば特定の権限なしで呼び出し可能なAPIです。
 
 ##### リクエストパラメータ
@@ -4477,11 +4487,15 @@ GET /v1/organizations
 > DELETE /v1/organizations/{org-id}
 自身の組織を削除するAPIです。
 
-##### 필요 권한
+##### 必要権限
 
 <!-- TODO: translate body -->
 
-##### 必要な権限
+**필요 권한**
+
+<!-- TODO: translate body -->
+
+**必要な権限**
 `Organization.Delete`
 
 ##### リクエストパラメータ
@@ -4516,11 +4530,15 @@ GET /v1/organizations
 > GET /v1/products
 提供されるサービス一覧を照会するAPIです。
 
-##### 필요 권한
+##### 必要権限
 
 <!-- TODO: translate body -->
 
-##### 必要な権限
+**필요 권한**
+
+<!-- TODO: translate body -->
+
+**必要な権限**
 会員であれば特定の権限なしで呼び出し可能なAPIです。
 
 ##### リクエストパラメータ
@@ -4585,11 +4603,15 @@ GET /v1/organizations
 > GET /v1/messages/role
 ロールの多言語リストを取得するAPIです。
 
-##### 필요 권한
+##### 必要権限
 
 <!-- TODO: translate body -->
 
-##### 必要権限
+**필요 권한**
+
+<!-- TODO: translate body -->
+
+**必要権限**
 会員であれば特定の権限なしで呼び出し可能なAPIです。
 
 ##### リクエストパラメータ

--- a/ja/toast-sdk-logncrash/android.md
+++ b/ja/toast-sdk-logncrash/android.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=522c249f15a2 -->
+
 ## Analytics > Log & Crash Search > TOAST SDK使用ガイド > Android
 
 <a id="section-1"></a>

--- a/ko/public-api/framework-api.md
+++ b/ko/public-api/framework-api.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=eddd49bbcebe -->
+
 # 프레임워크 API
 
 **NHN Cloud > Public API 사용 가이드 > 프레임워크 API**

--- a/ko/toast-sdk-logncrash/android.md
+++ b/ko/toast-sdk-logncrash/android.md
@@ -1,3 +1,5 @@
+<!-- pre-align:aligned sig=522c249f15a2 -->
+
 ## Analytics > Log & Crash Search > TOAST SDK 사용 가이드 > Android
 
 <a id="section-1"></a>


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260615-045021` |
| Scope | 56 doc(s) scanned · 8 file(s) changed · 51 unchanged · 1 skipped(error) |
| Self-verify | ⚠️ 8 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/71/ |
| Generated | 2026-06-15T07:08:52 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260615-045021`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Ftree%2Fpre-align%2Ffix-headings-20260615-045021&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fpull%2F349&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ja/nhncloud-sdk/getting-started-unity.md` | 0 | 0 | 0 | 1 | 0 | 0 | 0 | ⚠️ 2 |
| `ko/public-api/framework-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/public-api/framework-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/public-api/framework-api.md` | 0 | 5 | 0 | 0 | 0 | 10 | 0 | ✅ |
| `ko/toast-sdk-logncrash/android.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/toast-sdk-logncrash/android.md` | 0 | 19 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/toast-sdk-logncrash/android.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/user-guide.md` | 0 | 0 | 0 | 8 | 0 | 0 | 0 | ⚠️ 6 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/nhncloud-sdk/getting-started-unity.md`:
  - extra_in_target (ko#None/ja#18)
  - missing_in_target (ko#23/ja#None)
- `en/user-guide.md`:
  - missing_in_target (ko#24/en#None)
  - missing_in_target (ko#25/en#None)
  - missing_in_target (ko#26/en#None)
  - extra_in_target (ko#None/en#29)
  - extra_in_target (ko#None/en#30)
  - extra_in_target (ko#None/en#31)

</details>

<details><summary>변경 없이 건너뛴 문서 (51) — 이미 `ko`와 정렬됨 / 대상 파일 없음 (PR에서 제외)</summary>

- `architecture-icon.md`
- `console-guide.md`
- `console-user-guide.md`
- `nhncloud-sdk/creditcard-recognizer-android.md`
- `nhncloud-sdk/creditcard-recognizer-ios.md`
- `nhncloud-sdk/getting-started-android.md`
- `nhncloud-sdk/getting-started-ios.md`
- `nhncloud-sdk/getting-started-windows.md`
- `nhncloud-sdk/iap-ios.md`
- `nhncloud-sdk/iap-unity.md`
- `nhncloud-sdk/idcard-recognizer-android.md`
- `nhncloud-sdk/idcard-recognizer-ios.md`
- `nhncloud-sdk/log-collector-android.md`
- `nhncloud-sdk/log-collector-ios.md`
- `nhncloud-sdk/log-collector-ndk.md`
- `nhncloud-sdk/log-collector-reserved-fields.md`
- `nhncloud-sdk/log-collector-unity.md`
- `nhncloud-sdk/log-collector-windows.md`
- `nhncloud-sdk/overview.md`
- `nhncloud-sdk/push-android.md`
- `nhncloud-sdk/push-ios.md`
- `nhncloud-sdk/release-notes-android.md`
- `nhncloud-sdk/release-notes-ios.md`
- `nhncloud-sdk/release-notes-unity.md`
- `nhncloud-sdk/release-notes-windows.md`
- `nhncloud-sdk/symbol-uploader-android.md`
- `old/Getting Started.md`
- `old/Overview.md`
- `old/README.md`
- `old/Release Notes.md`
- `overview.md`
- `public-api/appkey.md`
- `public-api/auth-method-overview.md`
- `public-api/iaas-token.md`
- `public-api/overview.md`
- `public-api/partner-api.md`
- `public-api/project-integrated-appkey.md`
- `public-api/release-notes.md`
- `public-api/service-api.md`
- `public-api/supported-authentication-methods.md`
- `public-api/user-access-key-token.md`
- `public-api/user-access-key.md`
- `region-guide.md`
- `resource-policy.md`
- `security-policy.md`
- `terraform-guide.md`
- `toast-sdk-logncrash/ios.md`
- `toast-sdk-logncrash/unity.md`
- `trademark-guide/brand-guide.md`
- `trademark-guide/brand-overview.md`
- `trademark-guide/powered-by-nhncloud-guide.md`

</details>

<details><summary>⚠ 처리 오류/건너뜀 (1) — 닫히지 않은 코드펜스 등으로 정렬을 건너뛴 문서 (검토·소스 수정 필요)</summary>

- ja/nhncloud-sdk/iap-android.md: 닫히지 않은 코드펜스(ja) — 헤딩이 가려져 잘못된 stub을 만들 수 있어 건너뜀 (소스 문서의 ``` 짝을 먼저 고치세요)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/TOAST-Cloud`