### PR TITLE
chore(pre-align): align-v2 heading structure (public-api/framework-api.md) with ko

### DIFF
--- a/en/public-api/framework-api.md
+++ b/en/public-api/framework-api.md
@@ -6,12 +6,16 @@
 The following APIs allow you to manage your organization and projects, such as creating project members and assigning roles.
 Framework API uses User Access Key tokens for authentication and authorization when making API calls. The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key. For more information on issuing and using User Access Key tokens, please refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 
+<a id="public-api-domain"></a>
+
 ### Public API Domain
 `https://core.api.nhncloudservice.com/`
 
+<a id="common"></a>
+
 ### Common
 
-<a id="Request"></a>
+<a id="요청"></a>
 
 #### Request
 When calling the Public API, you must include the Request Header below.
@@ -21,7 +25,7 @@ When calling the Public API, you must include the Request Header below.
 |------------- |------------- | ------------- | ------------- | ------------- | 
 | Header |  x-nhn-authorization | String| Yes | Bearer type token issued to the user |
 
-<a id="Response"></a>
+<a id="응답"></a>
 
 #### Response
 When the Public API returns, the header part below is included in the response body.
@@ -41,6 +45,8 @@ When the Public API returns, the header part below is included in the response b
 |   resultCode | Integer| No | Result code. 0 is returned on success, or an error code on failure.  |
 |   resultMessage | String| No | Result message  |
 
+<a id="common-type"></a>
+
 #### Common Type
 <a id="common-type"></a>
 
@@ -59,6 +65,8 @@ When the Public API returns, the header part below is included in the response b
 !!! danger "Caution"
     If you set IP ACLs through **Organization Management > Governance Settings > Organization Governance Settings > IP ACL Settings**, those settings are also applied to calls to the framework API.
 
+
+<a id="api"></a>
 
 ### API
 
@@ -2358,7 +2366,7 @@ API to modify the role of a specified member in a project.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-단건-조회"></a>
+<a id="조직-IAM-계정-단건-조회"></a>
 #### View organization IAM members
 
 > GET "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2498,7 +2506,7 @@ API to get the IAM members in your organization.
 |   String | String| No |
 
 
-<a id="조직-IAM-멤버-목록-조회"></a>
+<a id="조직-IAM-계정-목록-조회"></a>
 #### List organization IAM members
 
 > GET "/v1/iam/organizations/{org-id}/members"
@@ -2618,7 +2626,7 @@ API to get a list of IAM members that belong to this organization.
 
 
 
-<a id="조직-IAM-멤버-추가"></a>
+<a id="조직-IAM-계정-추가"></a>
 #### Add an organization IAM member
 
 > POST "/v1/iam/organizations/{org-id}/members"
@@ -2692,7 +2700,7 @@ API to add IAM members to your organization.
 
 
 
-<a id="IAM-멤버-비밀번호-변경-이메일-전송"></a>
+<a id="IAM-계정-비밀번호-변경-이메일-전송"></a>
 #### Send an IAM member password change email
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail"
@@ -2740,7 +2748,7 @@ API to send an email to an IAM member to change their password.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-정보-수정"></a>
+<a id="조직-IAM-계정-정보-수정"></a>
 #### Modify organization IAM member information
 
 > PUT "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2809,7 +2817,7 @@ API to modify your organization's IAM member information.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-비밀번호-변경"></a>
+<a id="조직-IAM-계정-비밀번호-변경"></a>
 #### Change an organization IAM member password
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/set-password"
@@ -2903,7 +2911,7 @@ API to get IP ACL settings.
 |   ips | List<String>| Yes  | Allowed IPs | 
 |   productId | String| Yes  | Service ID<br>If undefined, set to Common Settings|
 
-<a id="조직-IAM-로그인-세션-설정-정보를-조회"></a>
+<a id="조직-IAM-계정-로그인-세션-설정-정보를-조회"></a>
 #### View organization IAM sign-in session settings information
 
 > GET "/v1/iam/organizations/{org-id}/settings/session"
@@ -2957,7 +2965,7 @@ API to get login session settings information.
 |   mobileSessionTimeoutMinutes | Integer| Yes | 	Mobile session timeout |
 |   sessionType | String| Yes | fixed/idle. The default is fixed  |
 
-<a id="조직-IAM-로그인-2차-인증에-대한-설정을-조회"></a>
+<a id="조직-IAM-계정-로그인-2차-인증에-대한-설정을-조회"></a>
 #### View settings for organizational IAM sign-in second factor authentication
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-mfa"
@@ -3049,7 +3057,7 @@ API to get settings for login two-factor authentication.
 |   String | Boolean| No | Activated or not<br>true (enabled), false (disabled)  |
 |   ipList | List<String>| No | List of exception IPs |
 
-<a id="조직-IAM-로그인-실패-보안-설정을-조회"></a>
+<a id="조직-IAM-계정-로그인-실패-보안-설정을-조회"></a>
 #### View Organization IAM Login Failure Security Settings
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-login-fail"
@@ -3414,7 +3422,7 @@ Available to all members. No specific permissions required.
 |   usageAggregationUnitCode | String| No | Usage aggregation units<br>RESOURCE_ID, COUNTER_NAME |
 
 
-<a id="프로젝트-Integrated-AppKey-조회"></a>
+<a id="프로젝트-통합-Appkey-조회"></a>
 #### Get Project Integrated AppKey
 
 > GET "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3538,7 +3546,7 @@ Available to all members. No specific permissions required.
 |   validTokenCount | Long| No | Number of valid tokens                      |
 
 
-<a id="Project-Integrated-AppKey-Registration"></a>
+<a id="프로젝트-통합-Appkey-등록"></a>
 #### Register a integrated project AppKey
 
 > POST "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3657,7 +3665,7 @@ Available to all members. No specific permissions required.
 |   tokenFormatCode | String | No | Token format code (OPAQUE, JWT) |
 
 
-<a id="Project-AppKey-Deletion"></a>
+<a id="프로젝트-통합-Appkey-삭제"></a>
 #### Delete a project integrated AppKey
 
 > DELETE "/v1/authentications/projects/{project-id}/project-appkeys/{app-key}"
@@ -4562,7 +4570,7 @@ An API to delete your own organization.
 |---|---|---|---|
 | header | [Common Response](#Response) | Yes | |
 
-<a id="Service-Information-List-Query"></a>
+<a id="서비스-정보-목록-조회"></a>
 #### Retrieve Service Information List
 
 > GET /v1/products
@@ -4700,6 +4708,8 @@ Available to all members. No specific permissions required.
 | jaJp | String | No | Japanese message |
 | zhCn | String | No | Chinese message |
 
+
+<a id="error-code"></a>
 
 ### Error Code
 

--- a/ja/public-api/framework-api.md
+++ b/ja/public-api/framework-api.md
@@ -6,8 +6,12 @@
 以下で紹介するAPIを通じて、プロジェクトメンバーを作成したり、ロールを付与するなど、組織とプロジェクトを管理できます。
 フレームワークAPIは、呼び出し時の認証/認可のためにUser Access Keyトークンを使用します。User Access Keyトークンは、User Access Keyに基づいて発行されるBearerタイプの一時的なアクセストークンです。User Access Keyトークンの発行及び使用に関する詳細は、[User Access Keyトークン](/nhncloud/ja/public-api/user-access-key-token)を参照してください。
 
+<a id="public-api-domain"></a>
+
 ### Public APIドメイン
 `https://core.api.nhncloudservice.com/`
+
+<a id="common"></a>
 
 ### 共通
 
@@ -21,7 +25,7 @@ Public APIを呼び出す時、下記のRequest Headerを必ず含める必要�
 |------------- |------------- | ------------- | ------------- | ------------- | 
 | Header |  x-nhn-authorization | String| Yes | ユーザーが発行されたBearerタイプトークン |
 
-<a id="レスポンス"></a>
+<a id="요청"></a>
 
 #### レスポンス
 Public APIの返却時、下記のヘッダ部分がレスポンス本文に含まれます。
@@ -41,6 +45,8 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   resultCode | Integer| No | 結果コード。成功した場合は0が返され、失敗した場合はエラーコードを返します。  |
 |   resultMessage | String| No | 結果メッセージ |
 
+<a id="응답"></a>
+
 #### 共通タイプ
 <a id="共通-タイプ"></a>
 
@@ -56,12 +62,16 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | uuid | String | 36文字 | メンバーのUUID |
 
 
+<a id="common-type"></a>
+
 #### ガバナンスIP ACL設定
 <a id="ガバナンス-IP-ACL-設定"></a>
 
 !!! danger "注意"
     **組織管理 > ガバナンス設定 > 組織ガバナンス設定 > IP ACL設定**でIP ACLを設定した場合、フレームワークAPI呼び出し時にもその設定が適用されます。
 
+
+<a id="api"></a>
 
 ### API
 
@@ -143,7 +153,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | GET | [/v1/messages/role](#ロール-説明-多言語-照会) | ロール説明多言語照会 |
 
 
-<a id="プロジェクト-メンバー-作成"></a>
+<a id="프로젝트-멤버-생성"></a>
 #### プロジェクトメンバー作成
 
 > POST "/v1/projects/{project-id}/members"
@@ -219,7 +229,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   header | [共通レスポンス](#レスポンス) | Yes |
 
 
-<a id="プロジェクト-追加"></a>
+<a id="프로젝트-추가"></a>
 #### プロジェクト追加
 
 > POST "/v1/organizations/{org-id}/projects"
@@ -281,7 +291,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   projectStatusCode | String| Yes   | プロジェクトの状態<br><ul><li>STABLE：正常に使用中の状態</li><li>CLOSED：支払いが完了し、プロジェクトが正常に閉じた状態</li><li>BLOCKED：管理者によって使用が禁止された状態</li><li>TERMINATED：延滞により、全てのリソースが削除された状態</li><li>DISABLED：全てのサービスが閉じた状態であるが、値が支払われていない状態</li></ul> | 
 
 
-<a id="プロジェクト-メンバー-単件-削除"></a>
+<a id="프로젝트-멤버-단건-삭제"></a>
 #### プロジェクトメンバー単件削除
 
 > DELETE "/v1/projects/{project-id}/members/{target-uuid}"
@@ -324,7 +334,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="プロジェクト-削除"></a>
+<a id="프로젝트-삭제"></a>
 #### プロジェクト削除
 
 > DELETE "/v1/projects/{project-id}"
@@ -370,7 +380,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="プロジェクト-サービス-終了"></a>
+<a id="프로젝트-서비스-종료"></a>
 #### プロジェクトサービス終了
 
 > DELETE "/v1/projects/{project-id}/products/{product-id}/disable"
@@ -427,7 +437,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   statusCode | String| Yes | サービス状態(STABLE, CLOSED) |
 
 
-<a id="プロジェクト-サービス-利用"></a>
+<a id="프로젝트-서비스-이용"></a>
 #### プロジェクトサービス利用
 
 > POST "/v1/projects/{project-id}/products/{product-id}/enable"
@@ -490,7 +500,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="組織-ロール-リスト-照会"></a>
+<a id="조직-역할-목록-조회"></a>
 #### 組織ロールリスト照会
 
 > GET "/v1/organizations/{org-id}/roles"
@@ -559,7 +569,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   roleName | String| Yes | ロール/権限名 |
 
 
-<a id="プロジェクト-ロール-リスト-照会"></a>
+<a id="프로젝트-역할-목록-조회"></a>
 #### プロジェクトロールリスト照会
 
 > GET "/v1/projects/{project-id}/roles"
@@ -612,7 +622,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   roles | List&lt;[RoleProtocol](#roleprotocol)>| Yes  | ロールリスト |
 |   totalCount | Integer| Yes  | 総数 |
 
-<a id="組織-ドメイン-検索"></a>
+<a id="조직-도메인-검색"></a>
 #### 組織ドメイン検索
 
 > GET "/v1/organizations/{org-id}/domains"
@@ -669,7 +679,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   orgDomainName | String| Yes | 組織ドメイン名 |
 
 
-<a id="組織-メンバー-単件-照会"></a>
+<a id="조직-멤버-단건-조회"></a>
 #### 組織メンバー単件照会
 
 > GET "/v1/organizations/{org-id}/members/{member-uuid}"
@@ -790,7 +800,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="組織-メンバー-リスト-照会"></a>
+<a id="조직-멤버-목록-조회"></a>
 #### 組織メンバーリスト照会
 
 > POST "/v1/organizations/{org-id}/members/search"
@@ -896,7 +906,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-全体-照会"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-전체-조회"></a>
 #### 組織のプロジェクト共通ロールグループ全体照会
 
 > GET "/v1/organizations/{org-id}/project-role-groups"
@@ -971,7 +981,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   roleGroupType | String| Yes | ロールグループの種類<br><ul><li>ORG:プロジェクト共通ロールグループ</li><li>ORG_ROLE_GROUP:組織ロールグループ</li><li>PROJECT:プロジェクトロールグループ</li> |
 
 
-<a id="サービス-階層-構造-照会"></a>
+<a id="서비스-계층-구조-조회"></a>
 #### サービス階層構造照会
 
 > GET "/v1/product-uis/hierarchy"
@@ -1035,7 +1045,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   productUiName | String| No|
 
 
-<a id="プロジェクトで-使用-中の-サービス-照会"></a>
+<a id="프로젝트에서-사용-중인-서비스-조회"></a>
 #### プロジェクトで使用中のサービス照会
 
 > GET "/v1/projects/{project-id}/products/{product-id}"
@@ -1113,7 +1123,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   updateUuid | String| No | サービスアプリキー修正者UUID  |
 
 
-<a id="プロジェクト-メンバー-単件-照会"></a>
+<a id="프로젝트-멤버-단건-조회"></a>
 #### プロジェクトメンバー単件照会
 
 > GET "/v1/projects/{project-id}/members/{member-uuid}"
@@ -1202,7 +1212,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="プロジェクト-メンバー-リスト-照会"></a>
+<a id="프로젝트-멤버-목록-조회"></a>
 #### プロジェクトメンバーリスト照会
 
 > POST "/v1/projects/{project-id}/members/search"
@@ -1286,7 +1296,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   uuid | String| No | メンバーUUID  |
 
 
-<a id="プロジェクト-ロール-グループ-単件-照会"></a>
+<a id="프로젝트-역할-그룹-단건-조회"></a>
 #### プロジェクトロールグループ単件照会
 
 > GET "/v1/projects/{project-id}/project-role-groups/{role-group-id}"
@@ -1365,7 +1375,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-単件-照会"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-단건-조회"></a>
 #### 組織のプロジェクト共通ロールグループ単件照会
 
 > GET "/v1/organizations/{org-id}/project-role-groups/{role-group-id}"
@@ -1432,7 +1442,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="プロジェクト-ロール-グループ-全体-照会"></a>
+<a id="프로젝트-역할-그룹-전체-조회"></a>
 #### プロジェクトロールグループ全体照会
 
 > GET "/v1/projects/{project-id}/project-role-groups"
@@ -1488,7 +1498,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)>| Yes | プロジェクトで使用可能なロールグループリスト |
 
-<a id="組織に-属する-プロジェクト-リスト-照会"></a>
+<a id="조직에-속한-프로젝트-목록-조회"></a>
 #### 組織に属するプロジェクトリスト照会
 
 > GET "/v1/organizations/{org-id}/projects"
@@ -1563,7 +1573,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   regDateTime | Date| Yes| プロジェクト登録日時 |
 
 
-<a id="使用-中の-組織-ガバナンス-リスト-照会"></a>
+<a id="사용-중인-조직-거버넌스-목록-조회"></a>
 #### 使用中の組織ガバナンスリスト照会
 
 > GET "/v1/organizations/{org-id}/governances"
@@ -1617,7 +1627,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   regDatetime | Date| No | ガバナンス使用設定日時 |
 
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-作成"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-생성"></a>
 #### 組織のプロジェクト共通ロールグループ作成
 
 > POST "/v1/organizations/{org-id}/project-role-groups"
@@ -1675,7 +1685,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-削除"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-삭제"></a>
 #### 組織のプロジェクト共通ロールグループ削除
 
 > DELETE "/v1/organizations/{org-id}/project-role-groups"
@@ -1720,7 +1730,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-情報-修正"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-정보-수정"></a>
 #### 組織のプロジェクト共通ロールグループ情報修正
 
 > PUT "/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos"
@@ -1768,7 +1778,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織の-プロジェクト-共通-ロール-グループ-ロール-修正"></a>
+<a id="조직의-프로젝트-공통-역할-그룹-역할-수정"></a>
 #### 組織のプロジェクト共通ロールグループロール修正
 
 > PUT "/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles"
@@ -1815,7 +1825,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="プロジェクト-ロール-グループ-作成"></a>
+<a id="프로젝트-역할-그룹-생성"></a>
 #### プロジェクトロールグループ作成
 
 > POST "/v1/projects/{project-id}/project-role-groups"
@@ -1856,7 +1866,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="プロジェクト-ロール-グループ-削除"></a>
+<a id="프로젝트-역할-그룹-삭제"></a>
 #### プロジェクトロールグループ削除
 
 > DELETE "/v1/projects/{project-id}/project-role-groups"
@@ -1897,7 +1907,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="プロジェクト-ロール-グループ-情報-修正"></a>
+<a id="프로젝트-역할-그룹-정보-수정"></a>
 #### プロジェクトロールグループ情報修正
 
 > PUT "/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos"
@@ -1938,7 +1948,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
 
-<a id="プロジェクト-ロール-グループ-ロール-修正"></a>
+<a id="프로젝트-역할-그룹-역할-수정"></a>
 #### プロジェクトロールグループロール修正
 
 > PUT "/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles"
@@ -1985,7 +1995,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織-ロール-グループ-全件-照会"></a>
+<a id="조직-역할-그룹-전체-조회"></a>
 
 #### 組織ロールグループ全件照会
 
@@ -2040,7 +2050,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | paging | [PagingResponse](#pagingresponse) | Yes | |
 | roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)> | Yes | 組織で使用可能なロールグループリスト |
 
-<a id="組織-ロール-グループ-個別-照会"></a>
+<a id="조직-역할-그룹-단건-조회"></a>
 
 #### 組織ロールグループ個別照会
 
@@ -2108,7 +2118,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | header | [共通レスポンス](#レスポンス) | Yes | |
 | roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | 関連ロールを含むロールグループ |
 
-<a id="組織-ロール-グループ-作成"></a>
+<a id="조직-역할-그룹-생성"></a>
 
 #### 組織ロールグループ作成
 
@@ -2144,7 +2154,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | ------------ | ------------- | ----------- | ------------ |
 | header | [共通レスポンス](#レスポンス) | Yes | |
 
-<a id="組織-ロール-グループ-削除"></a>
+<a id="조직-역할-그룹-삭제"></a>
 
 #### 組織ロールグループ削除
 
@@ -2180,7 +2190,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | ------------ | ------------- | ----------- | ------------ |
 | header | [共通レスポンス](#レスポンス) | Yes | |
 
-<a id="組織-ロール-グループ-情報-修正"></a>
+<a id="조직-역할-그룹-정보-수정"></a>
 
 #### 組織ロールグループ情報修正
 
@@ -2218,7 +2228,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | header | [共通レスポンス](#レスポンス) | Yes | |
 
 
-<a id="組織-ロール-グループ-ロール-修正"></a>
+<a id="조직-역할-그룹-역할-수정"></a>
 
 #### 組織ロールグループロール修正
 
@@ -2262,7 +2272,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | header | [共通レスポンス](#レスポンス) | Yes | |
 
 
-<a id="組織-メンバー-ロール-修正"></a>
+<a id="조직-멤버-역할-수정"></a>
 #### 組織メンバーロール修正
 
 > PUT "/v1/organizations/{org-id}/members/{member-uuid}"
@@ -2313,7 +2323,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="プロジェクト-メンバー-ロール-修正"></a>
+<a id="프로젝트-멤버-역할-수정"></a>
 #### プロジェクトメンバーロール修正
 
 > PUT "/v1/projects/{project-id}/members/{member-uuid}"
@@ -2352,7 +2362,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織-IAM-メンバー-単件-照会"></a>
+<a id="조직-IAM-계정-단건-조회"></a>
 #### 組織IAMメンバー単件照会
 
 > GET "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2492,7 +2502,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 |   role | String| No |
 
 
-<a id="組織-IAM-メンバー-リスト-照会"></a>
+<a id="조직-IAM-계정-목록-조회"></a>
 #### 組織IAMメンバーリスト照会
 
 > GET "/v1/iam/organizations/{org-id}/members"
@@ -2612,7 +2622,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="組織-IAM-メンバー-追加"></a>
+<a id="조직-IAM-계정-추가"></a>
 #### 組織IAMメンバー追加
 
 > POST "/v1/iam/organizations/{org-id}/members"
@@ -2686,7 +2696,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 
 
-<a id="IAM-メンバー-パスワード-変更-メール-送信"></a>
+<a id="IAM-계정-비밀번호-변경-이메일-전송"></a>
 #### IAMメンバーパスワード変更メール送信
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail"
@@ -2734,7 +2744,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織-IAM-メンバー-情報-修正"></a>
+<a id="조직-IAM-계정-정보-수정"></a>
 #### 組織IAMメンバー情報修正
 
 > PUT "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2802,7 +2812,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織-IAM-メンバー-パスワード-変更"></a>
+<a id="조직-IAM-계정-비밀번호-변경"></a>
 #### 組織IAMメンバーパスワード変更
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/set-password"
@@ -2847,7 +2857,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="組織-IP-ACL-リスト-照会"></a>
+<a id="조직-IP-ACL-목록-조회"></a>
 #### 組織IP ACLリスト照会
 
 > GET "/v1/organizations/{org-id}/products/ip-acl"
@@ -2896,7 +2906,7 @@ IP ACL設定を照会するAPIです。
 |   ips | List&lt;String>| Yes  | 許可IP | 
 |   productId | String| Yes  | サービスID<br>undefinedの場合、共通設定|
 
-<a id="組織-IAM-ログイン-セッション-設定-情報を-照会"></a>
+<a id="조직-IAM-계정-로그인-세션-설정-정보를-조회"></a>
 #### 組織IAMログインセッション設定情報を照会
 
 > GET "/v1/iam/organizations/{org-id}/settings/session"
@@ -2950,7 +2960,7 @@ IP ACL設定を照会するAPIです。
 |   mobileSessionTimeoutMinutes | Integer| Yes | 	モバイルセッションタイムアウト |
 |   sessionType | String| Yes | fixed/idle. デフォルト値はfixed  |
 
-<a id="組織-IAM-ログイン-2次-認証-の-設定を-照会"></a>
+<a id="조직-IAM-계정-로그인-2차-인증에-대한-설정을-조회"></a>
 #### 組織IAMログイン2段階認証の設定を照会
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-mfa"
@@ -3042,7 +3052,7 @@ IP ACL設定を照会するAPIです。
 |   enable | Boolean| No | 有効化かどうか<br>true(使用中), false(使用しない)  |
 |   ipList | List&lt;String>| No | 例外IPリスト |
 
-<a id="組織-IAM-ログイン-失敗-セキュリティ-設定を-照会"></a>
+<a id="조직-IAM-계정-로그인-실패-보안-설정을-조회"></a>
 #### 組織IAMログイン失敗セキュリティ設定を照会
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-login-fail"
@@ -3101,7 +3111,7 @@ IP ACL設定を照会するAPIです。
 |   limit | Integer| No | 試行許可回数 |
 |   blockMinutes | Integer| No | ログイン禁止時間 |
 
-<a id="従量制に-登録された-商品-価格-照会"></a>
+<a id="조직-IAM-계정-비밀번호-정책-조회"></a>
 #### 従量制に登録された商品価格照会
 
 > POST "/v1/billing/contracts/basic/products/prices/search"
@@ -3210,7 +3220,7 @@ IP ACL設定を照会するAPIです。
 |   slidingCalculationTypeCode | String| Yes | スライディング料金計算タイプ<br>NONE, SECTION_SUM, SECTION_SELECTED |
 |   useFixPriceYn | String| Yes | 固定金額かどうか(Y:固定金額、 N:単価計算)<br>Y:範囲に入る場合priceが金額になる<br>N: (使用量x単価)が金額になる |
 
-<a id="従量制に-登録された-サービス-リスト-照会"></a>
+<a id="종량제에-등록된-서비스-목록-조회"></a>
 #### 従量制に登録されたサービスリスト照会
 
 > GET "/v1/billing/contracts/basic/products"
@@ -3306,7 +3316,7 @@ IP ACL設定を照会するAPIです。
 |   usageAggregationUnitCode | String| No | 使用量集計単位<br>RESOURCE_ID, COUNTER_NAME |
 
 
-<a id="プロジェクト-統合-Appkey-照会"></a>
+<a id="프로젝트-통합-Appkey-조회"></a>
 #### プロジェクト統合Appkey照会
 
 > GET "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3365,7 +3375,7 @@ IP ACL設定を照会するAPIです。
 |   reIssueDatetime | Date| No | 再作成日時 |
 |   regDatetime | Date| No | 作成日時 |
 
-<a id="User-Access-Key-ID-リスト-照会"></a>
+<a id="User-Access-Key-ID-목록-조회"></a>
 #### User Access Key IDリスト照会
 
 > GET "/v1/authentications/user-access-keys"
@@ -3431,7 +3441,7 @@ IP ACL設定を照会するAPIです。
 |   lastTokenUsedDatetime | Long| No | トークンで最後に認証/認可した日時           |
 |   validTokenCount | Long| No | 有効なトークン数                    |
 
-<a id="プロジェクト-統合-Appkey-登録"></a>
+<a id="프로젝트-통합-Appkey-등록"></a>
 #### プロジェクト統合Appkey登録
 
 > POST "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3487,7 +3497,7 @@ IP ACL設定を照会するAPIです。
 |   authId | String| No | 内部的に管理する認証手段ID  |
 |   appKey | String| No | プロジェクト統合Appkey |
 
-<a id="User-Access-Key-ID-登録"></a>
+<a id="User-Access-Key-ID-등록"></a>
 #### User Access Key ID登録
 
 > POST "/v1/authentications/user-access-keys"
@@ -3549,7 +3559,7 @@ IP ACL設定を照会するAPIです。
 |   tokenExpiryPeriod | Long| No | トークンの有効期限(秒単位) |
 |   tokenFormatCode | String | No | トークンフォーマットコード(OPAQUE、JWT) |
 
-<a id="プロジェクト-統合-Appkey-削除"></a>
+<a id="프로젝트-통합-Appkey-삭제"></a>
 #### プロジェクト統合Appkey削除
 
 > DELETE "/v1/authentications/projects/{project-id}/project-appkeys/{app-key}"
@@ -3587,7 +3597,7 @@ IP ACL設定を照会するAPIです。
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
 
-<a id="User-Access-Key-ID-秘密-鍵-再発行"></a>
+<a id="User-Access-Key-ID-비밀-키-재발급"></a>
 #### User Access Key ID秘密鍵再発行
 
 > PUT "/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue"
@@ -3643,7 +3653,7 @@ OPAQUEトークン用のUser Access Key IDを停止するとOPAQUEトークン�
 |------------ | ------------- | ----------- | ------------ |
 |   secretAccessKey | String| Yes   | 秘密鍵 |
 
-<a id="User-Access-Key-ID-状態-修正"></a>
+<a id="User-Access-Key-ID-상태-수정"></a>
 #### User Access Key ID状態の修正
 
 > PUT "/v1/authentications/user-access-keys/{user-access-key-id}"
@@ -3686,7 +3696,7 @@ OPAQUEトークン用のUser Access Key IDを停止するとOPAQUEトークン�
 |------------ | ------------- | ----------- | ------------ |
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
-<a id="User-Access-Key-ID-削除"></a>
+<a id="User-Access-Key-ID-삭제"></a>
 #### User Access Key ID削除
 
 > DELETE "/v1/authentications/user-access-keys/{user-access-key-id}"
@@ -3723,7 +3733,7 @@ User Access Key IDを削除するAPIです。
 |   header | [共通レスポンス](#レスポンス)| Yes |
 
 
-<a id="トークン-リスト-照会"></a>
+<a id="토큰-목록-조회"></a>
 #### トークンリスト照会
 
 > GET "/v1/authentications/user-access-keys/{user-access-key-id}/tokens"
@@ -3785,7 +3795,7 @@ User Access Key IDで発行したOPAQUE トークンリストを照会するAPI�
 |   tokenId | Long         | Yes | トークンID              |
 
 
-<a id="トークン-複数-期限切れ"></a>
+<a id="토큰-다건-만료"></a>
 #### トークン複数期限切れ
 
 > DELETE "/v1/authentications/user-access-keys/{user-access-key-id}/tokens"
@@ -3825,7 +3835,7 @@ JWTトークンを発行したUser Access Key IDでリクエストしても、JW
 |   header | [共通レスポンス](#レスポンス)| Yes |
 
 
-<a id="プロジェクト-IAM-アカウント-作成"></a>
+<a id="프로젝트-IAM-계정-생성"></a>
 #### プロジェクトIAMアカウント作成
 
 > POST "/v1/iam/projects/{project-id}/members"
@@ -3898,7 +3908,7 @@ IAMアカウントをプロジェクトメンバーとして追加するAPIで�
 |   header | [共通レスポンス](#レスポンス) | Yes |
 
 
-<a id="プロジェクト-IAM-アカウント-一括-削除"></a>
+<a id="프로젝트-IAM-계정-다건-삭제"></a>
 #### プロジェクトIAMアカウント一括削除
 
 > DELETE "/v1/iam/projects/{project-id}/members"
@@ -3945,7 +3955,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 |   header | [共通レスポンス](#レスポンス)| Yes |
 
 
-<a id="プロジェクト-IAM-アカウント-単件-照会"></a>
+<a id="프로젝트-IAM-계정-단건-조회"></a>
 #### プロジェクトIAMアカウント単件照会
 
 > GET "/v1/iam/projects/{project-id}/members/{member-uuid}"
@@ -4035,7 +4045,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 
 
-<a id="プロジェクト-IAM-アカウント-リスト-照会"></a>
+<a id="프로젝트-IAM-계정-목록-조회"></a>
 #### プロジェクトIAMアカウントリスト照会
 
 > GET "/v1/iam/projects/{project-id}/members"
@@ -4110,7 +4120,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 |   recentPasswordModifyYmdt | Date| No | 最近のパスワード変更日時 |
 
 
-<a id="プロジェクト-IAM-アカウント-ロール-修正"></a>
+<a id="프로젝트-IAM-계정-역할-수정"></a>
 #### プロジェクトIAMアカウントロール修正
 
 > PUT "/v1/iam/projects/{project-id}/members/{member-uuid}"
@@ -4149,7 +4159,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 |   header | [共通レスポンス](#レスポンス)| Yes   |
 
 
-<a id="組織-下位-メンバーの-全ての-認証情報-リスト-照会"></a>
+<a id="조직-하위-멤버의-모든-인증정보-목록-조회"></a>
 #### 組織下位メンバー認証情報リスト照会
 
 > GET "/v1/authentications/organizations/{org-id}/user-access-keys"
@@ -4231,7 +4241,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 | lastTokenUsedDatetime | Date | No | トークン最終使用日時 |
 | validTokenCount | Long | No | 有効なトークン数 |
 
-<a id="自分の組織一覧の照会"></a>
+<a id="자신의-조직-목록-조회"></a>
 #### 自分の組織一覧の照会
 
 **[Method, URL]**
@@ -4351,7 +4361,7 @@ GET /v1/organizations
 | domainName | String | Yes | 組織ドメイン名 |
 
 
-<a id="自分の-組織-追加"></a>
+<a id="자신의-조직-추가"></a>
 #### 自分の組織の追加
 
 > POST /v1/organizations
@@ -4413,7 +4423,7 @@ GET /v1/organizations
 | restrictTypes | List&lt;String> | Yes | 制約対象一覧 |
 
 
-<a id="組織個別削除"></a>
+<a id="조직-단건-삭제"></a>
 #### 組織の個別削除
 
 > DELETE /v1/organizations/{org-id}
@@ -4448,7 +4458,7 @@ GET /v1/organizations
 | header | [共通レスポンス](#レスポンス) | Yes | |
 
 
-<a id="サービス情報一覧照会"></a>
+<a id="서비스-정보-목록-조회"></a>
 #### サービス情報一覧照会
 
 > GET /v1/products
@@ -4513,7 +4523,7 @@ GET /v1/organizations
 | productName | String | Yes | サービス名 |
 
 
-<a id="ロール-説明-多言語-照会"></a>
+<a id="역할-설명-다국어-조회"></a>
 #### ロール説明多言語照会
 
 > GET /v1/messages/role
@@ -4587,6 +4597,8 @@ GET /v1/organizations
 | jaJp | String | No | 日本語メッセージ |
 | zhCn | String | No | 中国語メッセージ |
 
+
+<a id="error-code"></a>
 
 ### エラーコード
 

--- a/ko/public-api/framework-api.md
+++ b/ko/public-api/framework-api.md
@@ -6,8 +6,12 @@
 다음에서 소개하는 API를 통해 프로젝트 멤버를 생성하거나 역할을 부여하는 등 조직과 프로젝트를 관리할 수 있습니다.
 프레임워크 API는 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 
+<a id="public-api-domain"></a>
+
 ### Public API 도메인
 `https://core.api.nhncloudservice.com/`
+
+<a id="common"></a>
 
 ### 공통
 
@@ -41,6 +45,8 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 |   resultCode | Integer| No | 결과 코드. 성공 시 0이 반환되며, 실패 시 오류 코드 반환  |
 |   resultMessage | String| No | 결과 메시지  |
 
+<a id="common-type"></a>
+
 #### 공통 타입
 <a id="공통-타입"></a>
 
@@ -59,6 +65,8 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 !!! danger "주의"
     * **조직 관리 > 거버넌스 설정 > 조직 거버넌스 설정 > IP ACL 설정**을 통해 IP ACL을 설정했을 경우, 프레임워크 API 호출 시에도 해당 설정이 적용됩니다.
 
+
+<a id="api"></a>
 
 ### API
 
@@ -4708,6 +4716,8 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 | jaJp | String | No | 일본어 메시지 |
 | zhCn | String | No | 중국어 메시지 |
 
+
+<a id="error-code"></a>
 
 ### 오류 코드
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260616-061009` |
| Scope | 1 doc(s) scanned · 3 file(s) changed |
| Self-verify | ⚠️ 11 mismatch(es) remain |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/101/ |
| Generated | 2026-06-16T08:56:38 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260616-061009`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fblob%2Fpre-align%2Ffix-headings-20260616-061009%2Fko%2Fpublic-api%2Fframework-api.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fpull%2F352&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/public-api/framework-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/public-api/framework-api.md` | 0 | 0 | 0 | 15 | 0 | 0 | 0 | ✅ |
| `ja/public-api/framework-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ⚠️ 11 |

<details><summary>남은 불일치 (검토 필요)</summary>

- `ja/public-api/framework-api.md`:
  - extra_in_target (ko#None/ja#4)
  - missing_in_target (ko#293/ja#None)
  - missing_in_target (ko#294/ja#None)
  - missing_in_target (ko#295/ja#None)
  - missing_in_target (ko#296/ja#None)
  - missing_in_target (ko#297/ja#None)
  - missing_in_target (ko#298/ja#None)
  - missing_in_target (ko#299/ja#None)
  - missing_in_target (ko#300/ja#None)
  - missing_in_target (ko#301/ja#None)
  - missing_in_target (ko#302/ja#None)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/TOAST-Cloud`