### PR TITLE
chore(pre-align): align-v2 heading structure (public-api/framework-api.md) with ko

### DIFF
--- a/en/public-api/framework-api.md
+++ b/en/public-api/framework-api.md
@@ -6,12 +6,16 @@
 The following APIs allow you to manage your organization and projects, such as creating project members and assigning roles.
 Framework API uses User Access Key tokens for authentication and authorization when making API calls. The User Access Key token is a temporary, Bearer-type access token issued from a User Access Key. For more information on issuing and using User Access Key tokens, please refer to the [User Access Key Token](/nhncloud/en/public-api/user-access-key-token).
 
+<a id="public-api-domain"></a>
+
 ### Public API Domain
 `https://core.api.nhncloudservice.com/`
 
+<a id="common"></a>
+
 ### Common
 
-<a id="Request"></a>
+<a id="요청"></a>
 
 #### Request
 When calling the Public API, you must include the Request Header below.
@@ -21,7 +25,7 @@ When calling the Public API, you must include the Request Header below.
 |------------- |------------- | ------------- | ------------- | ------------- | 
 | Header |  x-nhn-authorization | String| Yes | Bearer type token issued to the user |
 
-<a id="Response"></a>
+<a id="응답"></a>
 
 #### Response
 When the Public API returns, the header part below is included in the response body.
@@ -41,6 +45,8 @@ When the Public API returns, the header part below is included in the response b
 |   resultCode | Integer| No | Result code. 0 is returned on success, or an error code on failure.  |
 |   resultMessage | String| No | Result message  |
 
+<a id="common-type"></a>
+
 #### Common Type
 <a id="common-type"></a>
 
@@ -59,6 +65,8 @@ When the Public API returns, the header part below is included in the response b
 !!! danger "Caution"
     If you set IP ACLs through **Organization Management > Governance Settings > Organization Governance Settings > IP ACL Settings**, those settings are also applied to calls to the framework API.
 
+
+<a id="api"></a>
 
 ### API
 
@@ -2358,7 +2366,7 @@ API to modify the role of a specified member in a project.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-단건-조회"></a>
+<a id="조직-IAM-계정-단건-조회"></a>
 #### View organization IAM members
 
 > GET "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2498,7 +2506,7 @@ API to get the IAM members in your organization.
 |   String | String| No |
 
 
-<a id="조직-IAM-멤버-목록-조회"></a>
+<a id="조직-IAM-계정-목록-조회"></a>
 #### List organization IAM members
 
 > GET "/v1/iam/organizations/{org-id}/members"
@@ -2618,7 +2626,7 @@ API to get a list of IAM members that belong to this organization.
 
 
 
-<a id="조직-IAM-멤버-추가"></a>
+<a id="조직-IAM-계정-추가"></a>
 #### Add an organization IAM member
 
 > POST "/v1/iam/organizations/{org-id}/members"
@@ -2692,7 +2700,7 @@ API to add IAM members to your organization.
 
 
 
-<a id="IAM-멤버-비밀번호-변경-이메일-전송"></a>
+<a id="IAM-계정-비밀번호-변경-이메일-전송"></a>
 #### Send an IAM member password change email
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail"
@@ -2740,7 +2748,7 @@ API to send an email to an IAM member to change their password.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-정보-수정"></a>
+<a id="조직-IAM-계정-정보-수정"></a>
 #### Modify organization IAM member information
 
 > PUT "/v1/iam/organizations/{org-id}/members/{member-uuid}"
@@ -2809,7 +2817,7 @@ API to modify your organization's IAM member information.
 |------------ | ------------- | ----------- | ------------ |
 |   header | [Common response](#Response)| Yes   |
 
-<a id="조직-IAM-멤버-비밀번호-변경"></a>
+<a id="조직-IAM-계정-비밀번호-변경"></a>
 #### Change an organization IAM member password
 
 > POST "/v1/iam/organizations/{org-id}/members/{member-id}/set-password"
@@ -2903,7 +2911,7 @@ API to get IP ACL settings.
 |   ips | List<String>| Yes  | Allowed IPs | 
 |   productId | String| Yes  | Service ID<br>If undefined, set to Common Settings|
 
-<a id="조직-IAM-로그인-세션-설정-정보를-조회"></a>
+<a id="조직-IAM-계정-로그인-세션-설정-정보를-조회"></a>
 #### View organization IAM sign-in session settings information
 
 > GET "/v1/iam/organizations/{org-id}/settings/session"
@@ -2957,7 +2965,7 @@ API to get login session settings information.
 |   mobileSessionTimeoutMinutes | Integer| Yes | 	Mobile session timeout |
 |   sessionType | String| Yes | fixed/idle. The default is fixed  |
 
-<a id="조직-IAM-로그인-2차-인증에-대한-설정을-조회"></a>
+<a id="조직-IAM-계정-로그인-2차-인증에-대한-설정을-조회"></a>
 #### View settings for organizational IAM sign-in second factor authentication
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-mfa"
@@ -3049,7 +3057,7 @@ API to get settings for login two-factor authentication.
 |   String | Boolean| No | Activated or not<br>true (enabled), false (disabled)  |
 |   ipList | List<String>| No | List of exception IPs |
 
-<a id="조직-IAM-로그인-실패-보안-설정을-조회"></a>
+<a id="조직-IAM-계정-로그인-실패-보안-설정을-조회"></a>
 #### View Organization IAM Login Failure Security Settings
 
 > GET "/v1/iam/organizations/{org-id}/settings/security-login-fail"
@@ -3414,7 +3422,7 @@ Available to all members. No specific permissions required.
 |   usageAggregationUnitCode | String| No | Usage aggregation units<br>RESOURCE_ID, COUNTER_NAME |
 
 
-<a id="프로젝트-Integrated-AppKey-조회"></a>
+<a id="프로젝트-통합-Appkey-조회"></a>
 #### Get Project Integrated AppKey
 
 > GET "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3538,7 +3546,7 @@ Available to all members. No specific permissions required.
 |   validTokenCount | Long| No | Number of valid tokens                      |
 
 
-<a id="Project-Integrated-AppKey-Registration"></a>
+<a id="프로젝트-통합-Appkey-등록"></a>
 #### Register a integrated project AppKey
 
 > POST "/v1/authentications/projects/{project-id}/project-appkeys"
@@ -3657,7 +3665,7 @@ Available to all members. No specific permissions required.
 |   tokenFormatCode | String | No | Token format code (OPAQUE, JWT) |
 
 
-<a id="Project-AppKey-Deletion"></a>
+<a id="프로젝트-통합-Appkey-삭제"></a>
 #### Delete a project integrated AppKey
 
 > DELETE "/v1/authentications/projects/{project-id}/project-appkeys/{app-key}"
@@ -4562,7 +4570,7 @@ An API to delete your own organization.
 |---|---|---|---|
 | header | [Common Response](#Response) | Yes | |
 
-<a id="Service-Information-List-Query"></a>
+<a id="서비스-정보-목록-조회"></a>
 #### Retrieve Service Information List
 
 > GET /v1/products
@@ -4700,6 +4708,8 @@ Available to all members. No specific permissions required.
 | jaJp | String | No | Japanese message |
 | zhCn | String | No | Chinese message |
 
+
+<a id="error-code"></a>
 
 ### Error Code
 

--- a/ko/public-api/framework-api.md
+++ b/ko/public-api/framework-api.md
@@ -6,8 +6,12 @@
 다음에서 소개하는 API를 통해 프로젝트 멤버를 생성하거나 역할을 부여하는 등 조직과 프로젝트를 관리할 수 있습니다.
 프레임워크 API는 호출 시 인증/인가를 위해 User Access Key 토큰을 사용합니다. User Access Key 토큰은 User Access Key를 기반으로 발급되는 Bearer 타입의 일시적 액세스 토큰입니다. User Access Key 토큰 발급 및 사용에 대한 자세한 내용은 [User Access Key 토큰](/nhncloud/ko/public-api/user-access-key-token)을 참고하세요.
 
+<a id="public-api-domain"></a>
+
 ### Public API 도메인
 `https://core.api.nhncloudservice.com/`
+
+<a id="common"></a>
 
 ### 공통
 
@@ -41,6 +45,8 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 |   resultCode | Integer| No | 결과 코드. 성공 시 0이 반환되며, 실패 시 오류 코드 반환  |
 |   resultMessage | String| No | 결과 메시지  |
 
+<a id="common-type"></a>
+
 #### 공통 타입
 <a id="공통-타입"></a>
 
@@ -59,6 +65,8 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 !!! danger "주의"
     * **조직 관리 > 거버넌스 설정 > 조직 거버넌스 설정 > IP ACL 설정**을 통해 IP ACL을 설정했을 경우, 프레임워크 API 호출 시에도 해당 설정이 적용됩니다.
 
+
+<a id="api"></a>
 
 ### API
 
@@ -4708,6 +4716,8 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 | jaJp | String | No | 일본어 메시지 |
 | zhCn | String | No | 중국어 메시지 |
 
+
+<a id="error-code"></a>
 
 ### 오류 코드
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `pre-align/fix-headings-20260616-061009` |
| Scope | 1 doc(s) scanned · 2 file(s) changed · ⛔ 1 분석 오류 |
| Self-verify | ✅ all aligned |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/104/ |
| Generated | 2026-06-17T01:24:54 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`pre-align/fix-headings-20260616-061009`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fblob%2Fpre-align%2Ffix-headings-20260616-061009%2Fko%2Fpublic-api%2Fframework-api.md&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FTOAST-Cloud%2Fpull%2F358&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/public-api/framework-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/public-api/framework-api.md` | 0 | 0 | 0 | 15 | 0 | 0 | 0 | ✅ |
| `ja/public-api/framework-api.md` | — | — | — | — | — | — | — | ⛔ 분석 오류 |

<details><summary>⛔ 분석 오류 상세 (1) — 위 표에서 ⛔로 표시된 파일들 (CLI 타임아웃, 닫히지 않은 코드펜스, 엔진 오류 등; 검토·재시도 필요)</summary>

- ja/public-api/framework-api.md: Command '['claude', '-p', '--output-format', 'json', '--model', 'claude-sonnet-4-6']' timed out after 600 seconds

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/TOAST-Cloud`