### PR TITLE
chore(pre-align): rewrite framework-api.md link fragments to canonical anchor ids

### DIFF
--- a/en/public-api/framework-api.md
+++ b/en/public-api/framework-api.md
@@ -73,43 +73,43 @@ When the Public API returns, the header part below is included in the response b
 
 | Method | HTTP Request | Description |
 |------------- | ------------- | -------------|
-| POST |[/v1/projects/{project-id}/members](#프로젝트-멤버-생성) | Create a project member |
-| POST |[/v1/organizations/{org-id}/projects](#프로젝트-추가) | Add a project |
-| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#프로젝트-멤버-단건-삭제) | Delete a single project member |
-| DELETE |[/v1/projects/{project-id}](#프로젝트-삭제) | Delete a project |
-| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#프로젝트-서비스-종료) | End a project service |
-| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#프로젝트-서비스-이용) | Use a project service |
-| GET |[/v1/organizations/{org-id}/roles](#조직-역할-목록-조회) | List organization roles |
-| GET |[/v1/projects/{project-id}/roles](#프로젝트-역할-목록-조회) | List project roles |
-| GET |[/v1/organizations/{org-id}/domains](#조직-도메인-검색) | Search for an organization domain |
-| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#조직-멤버-단건-조회) | View a organization member |
-| POST |[/v1/organizations/{org-id}/members/search](#조직-멤버-목록-조회) | List organization members |
-| GET |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-전체-조회) | View all common role groups for projects in the organization |
-| GET |[/v1/product-uis/hierarchy](#서비스-계층-구조-조회) | View service hierarchy |
-| GET |[/v1/projects/{project-id}/products/{product-id}](#프로젝트에서-사용-중인-서비스-조회) | View a service used in the project |
-| GET |[/v1/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-단건-조회) | View a project member |
-| POST |[/v1/projects/{project-id}/members/search](#프로젝트-멤버-목록-조회) | List project members |
-| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#프로젝트-역할-그룹-단건-조회) | View a project role group |
-| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#조직의-프로젝트-공통-역할-그룹-단건-조회) | View a common role group for the project in the organization |
-| GET |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-전체-조회) | View all project role groups |
-| GET |[/v1/organizations/{org-id}/projects](#조직에-속한-프로젝트-목록-조회) | List projects in your organization |
-| GET |[/v1/organizations/{org-id}/governances](#사용-중인-조직-거버넌스-목록-조회) | List organization governance in use |
-| POST |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-생성) | Create a common role group for projects in the organization |
-| DELETE |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-삭제) | Delete a project common role group in the organization |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#조직의-프로젝트-공통-역할-그룹-정보-수정) | Modify your organization's project common role group information |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#조직의-프로젝트-공통-역할-그룹-역할-수정) | Modify your organization's project common roles group roles |
-| POST |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-생성) | Create a project role group |
-| DELETE |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-삭제) | Delete a project role group |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#프로젝트-역할-그룹-정보-수정) | Edit project role group information |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#프로젝트-역할-그룹-역할-수정) | Modify project role group roles |
-| GET |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-전체-조회) | View all organization role groups |
-| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#조직-역할-그룹-단건-조회) | View a single organization role group |
-| POST |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-생성) | Create an organization role group |
-| DELETE |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-삭제) | Delete an organization role group |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#조직-역할-그룹-정보-수정) | Modify an organization role group information |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#조직-역할-그룹-역할-수정) | Modify an organization role group's role |
-| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#조직-멤버-역할-수정) | Modify organization member roles |
-| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-역할-수정) | Modify project member roles |
+| POST |[/v1/projects/{project-id}/members](#create-a-project-member) | Create a project member |
+| POST |[/v1/organizations/{org-id}/projects](#add-a-project) | Add a project |
+| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#delete-a-single-project-member) | Delete a single project member |
+| DELETE |[/v1/projects/{project-id}](#delete-a-project) | Delete a project |
+| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#end-a-project-service) | End a project service |
+| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#use-a-service-product) | Use a project service |
+| GET |[/v1/organizations/{org-id}/roles](#list-organization-roles) | List organization roles |
+| GET |[/v1/projects/{project-id}/roles](#list-project-roles) | List project roles |
+| GET |[/v1/organizations/{org-id}/domains](#search-for-an-organization-domain) | Search for an organization domain |
+| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#view-a-organization-member) | View a organization member |
+| POST |[/v1/organizations/{org-id}/members/search](#list-organization-members) | List organization members |
+| GET |[/v1/organizations/{org-id}/project-role-groups](#view-all-common-role-groups-for-projects-in-the-organization) | View all common role groups for projects in the organization |
+| GET |[/v1/product-uis/hierarchy](#view-service-hierarchy) | View service hierarchy |
+| GET |[/v1/projects/{project-id}/products/{product-id}](#view-a-service-used-in-the-project) | View a service used in the project |
+| GET |[/v1/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | View a project member |
+| POST |[/v1/projects/{project-id}/members/search](#list-project-members) | List project members |
+| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#view-a-project-role-group) | View a project role group |
+| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#view-a-common-role-group-for-the-project-in-the-organization) | View a common role group for the project in the organization |
+| GET |[/v1/projects/{project-id}/project-role-groups](#view-all-project-role-groups) | View all project role groups |
+| GET |[/v1/organizations/{org-id}/projects](#list-projects-in-your-organization) | List projects in your organization |
+| GET |[/v1/organizations/{org-id}/governances](#list-organization-governance-in-use) | List organization governance in use |
+| POST |[/v1/organizations/{org-id}/project-role-groups](#create-a-common-role-group-for-projects-in-the-organization) | Create a common role group for projects in the organization |
+| DELETE |[/v1/organizations/{org-id}/project-role-groups](#delete-a-project-common-role-group-in-the-organization) | Delete a project common role group in the organization |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#modify-your-organizations-project-common-role-group-information) | Modify your organization's project common role group information |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#modify-your-organizations-project-common-roles-group-roles) | Modify your organization's project common roles group roles |
+| POST |[/v1/projects/{project-id}/project-role-groups](#create-a-project-role-group) | Create a project role group |
+| DELETE |[/v1/projects/{project-id}/project-role-groups](#delete-a-project-role-group) | Delete a project role group |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#edit-project-role-group-information) | Edit project role group information |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#modify-project-role-group-roles) | Modify project role group roles |
+| GET |[/v1/organizations/{org-id}/org-role-groups](#view-all-organization-role-groups) | View all organization role groups |
+| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#view-a-single-organization-role-group) | View a single organization role group |
+| POST |[/v1/organizations/{org-id}/org-role-groups](#create-organization-role-group) | Create an organization role group |
+| DELETE |[/v1/organizations/{org-id}/org-role-groups](#delete-organization-role-group) | Delete an organization role group |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#modify-organization-role-group-information) | Modify an organization role group information |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#modify-an-organization-role-groups-role) | Modify an organization role group's role |
+| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#modify-organization-member-roles) | Modify organization member roles |
+| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#modify-project-member-roles) | Modify project member roles |
 | GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#조직-IAM-멤버-단건-조회) | View organization IAM members |
 | GET |[/v1/iam/organizations/{org-id}/members](#조직-IAM-멤버-목록-조회) | List organization IAM members |
 | POST |[/v1/iam/organizations/{org-id}/members](#조직-IAM-멤버-추가) | Add an organization IAM member |
@@ -119,31 +119,31 @@ When the Public API returns, the header part below is included in the response b
 | GET |[/v1/iam/organizations/{org-id}/settings/session](#조직-IAM-로그인-세션-설정-정보를-조회) | View organization IAM sign-in session settings information |
 | GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#조직-IAM-로그인-2차-인증에-대한-설정을-조회) | View settings for organizational IAM sign-in second factor authentication |
 | GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#조직-IAM-로그인-실패-보안-설정을-조회) | View Organization IAM Login Failure Security Settings |
-| GET |[/v1/iam/organizations/{org-id}/settings/password-rule](#조직-IAM-계정-비밀번호-정책-조회) | Get your organization's IAM account password policy |
-| GET |[/v1/organizations/{org-id}/products/ip-acl](#조직-IP-ACL-목록-조회) | Listorganization IP ACLs |
-| POST |[/v1/billing/contracts/basic/products/prices/search](#종량제에-등록된-서비스-가격-조회) | Get the price of a service on a pay-as-you-go subscription |
-| GET |[/v1/billing/contracts/basic/products](#종량제에-등록된-서비스-목록-조회) | List services enrolled in a pay-as-you-go subscription |
+| GET |[/v1/iam/organizations/{org-id}/settings/password-rule](#get-your-organizations-iam-account-password-policy) | Get your organization's IAM account password policy |
+| GET |[/v1/organizations/{org-id}/products/ip-acl](#listorganization-ip-acls) | Listorganization IP ACLs |
+| POST |[/v1/billing/contracts/basic/products/prices/search](#get-the-price-of-a-service-on-a-pay-as-you-go-subscription) | Get the price of a service on a pay-as-you-go subscription |
+| GET |[/v1/billing/contracts/basic/products](#list-services-enrolled-in-a-pay-as-you-go-subscription) | List services enrolled in a pay-as-you-go subscription |
 | GET |[/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-AppKey-조회) | Get Project AppKey |
-| GET |[/v1/authentications/user-access-keys](#User-Access-Key-ID-목록-조회) | ListUser Access Key IDs |
+| GET |[/v1/authentications/user-access-keys](#listuser-access-key-ids) | ListUser Access Key IDs |
 | POST |[/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-AppKey-등록) | Register a project AppKey |
-| POST |[/v1/authentications/user-access-keys](#User-Access-Key-ID-등록) | Register a User Access Key ID |
+| POST |[/v1/authentications/user-access-keys](#register-a-user-access-key-id) | Register a User Access Key ID |
 | DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#프로젝트-AppKey-삭제) | Delete a project AppKey |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#User-Access-Key-ID-비밀-키-재발급) | Reissue the User Access Key ID secret key |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-상태-수정) | Modify User Access Key ID status |
-| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-삭제) | Delete a User Access Key ID |
-| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#토큰-목록-조회)                               | Get Token list                    |
-| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#토큰-다건-만료)                               | Expire multiple tokens                    |
-| POST |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-생성) | Create a project IAM account |
-| DELETE |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-다건-삭제) | Delete multiple project IAM accounts |
-| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-단건-조회) | View a project IAM account |
-| GET |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-목록-조회) | View project IAM accounts |
-| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#프로젝트-IAM-계정-역할-수정) | Modify project IAM account roles |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#reissue-the-user-access-key-id-secret-key) | Reissue the User Access Key ID secret key |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#modify-user-access-key-id-status) | Modify User Access Key ID status |
+| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#delete-a-user-access-key-id) | Delete a User Access Key ID |
+| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#get-a-list-of-tokens)                               | Get Token list                    |
+| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#expire-multiple-tokens)                               | Expire multiple tokens                    |
+| POST |[/v1/iam/projects/{project-id}/members](#create-a-project-iam-account) | Create a project IAM account |
+| DELETE |[/v1/iam/projects/{project-id}/members](#delete-multiple-project-iam-accounts) | Delete multiple project IAM accounts |
+| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | View a project IAM account |
+| GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | View project IAM accounts |
+| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | Modify project IAM account roles |
 | GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#조직-하위-멤버의-모든-인증정보-리스트-조회) | View all credentials of members under organizations |
-| GET | [/v1/organizations](#자신의-조직-목록-조회) | View your own organization list |
-| POST | [/v1/organizations](#자신의-조직-추가) | Add your own organization |
-| DELETE | [/v1/organizations/{org-id}](#조직-단건-삭제) | Delete a single organization |
-| GET | [/v1/products](#서비스-정보-목록-조회) | View service information lists |
-| GET | [/v1/messages/role](#역할-설명-다국어-조회) | View role descriptions in multiple languages |
+| GET | [/v1/organizations](#view-your-own-organization-list) | View your own organization list |
+| POST | [/v1/organizations](#add-your-own-organization) | Add your own organization |
+| DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | Delete a single organization |
+| GET | [/v1/products](#retrieve-service-information-list) | View service information lists |
+| GET | [/v1/messages/role](#view-role-descriptions-by-multiple-language) | View role descriptions in multiple languages |
 
 
 <a id="create-a-project-member"></a>
@@ -222,7 +222,7 @@ API to add members to a project.
 
 | Name | Type           | Required | Description |   
 |------------ |--------------| ------- | ------------ |
-|   header | [Common response](#Response) | Yes |
+|   header | [Common response](#common-response) | Yes |
 
 
 <a id="add-a-project"></a>
@@ -280,7 +280,7 @@ API to add projects to your organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes  |
+|   header | [Common response](#common-response)| Yes  |
 |   regDateTime | Date| Yes   | When the project is created | 
 |   description | String| No   | Project description | 
 |   ownerId | String| Yes   | Project owner member ID | 
@@ -332,7 +332,7 @@ API to delete a user from a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 
 
 
@@ -381,7 +381,7 @@ You'll need one permission from the list below
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 
 
 
@@ -432,7 +432,7 @@ API to disable a user-specified service so that it is no longer used by this pro
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   childProducts | List<ChildProduct>| No   | Subservice information for that service, not included if there are no subservices.<br>Requires you to disable the child service first and then disable the service.|
 
 ##### ChildProduct
@@ -492,7 +492,7 @@ An API that requests to enable a service you specify to be available in your pro
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   appKey | String| Yes | AppKey information for the service your project is using|
 |   parentProduct | ParentProduct| No | Shows parent service information if it exists, or does not include it if no parent service exists |
 |   secretKey | String| No| Secret key information for the service your project is using.<br> Only available for services that use secret keys |
@@ -566,7 +566,7 @@ API to request a list of roles that can be granted to users in your organization
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   roles | List<RoleProtocol>| Yes  | Roles list |
 |   totalCount | Integer| Yes  | Total count |
 
@@ -635,7 +635,7 @@ API to request a list of roles that can be granted to project users.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   roles | List<[RoleProtocol](#roleprotocol)>| Yes  | Roles list |
 |   totalCount | Integer| Yes  | Total count |
 
@@ -686,7 +686,7 @@ API to look up domains for a specific organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   domainList | List<OrgDomainProtocol>| Yes  |
 
 
@@ -773,7 +773,7 @@ API to get members belonging to an organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   orgMember | OrgMemberRoleBundleProtocol| No  | Added member information, not included on error |
 
 ##### OrgMemberRoleBundleProtocol
@@ -900,7 +900,7 @@ API to get a list of NHN Cloud members belonging to an organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   orgMembers | List<OrgMemberWithInviteMemberrotocol>| Yes | Organization member list |
 |   paging | PagingResponse| Yes | About the page |
 
@@ -993,7 +993,7 @@ API to get a list of project common role groups set up by your organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes  |
+|   header | [Common response](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List<RoleGroupProtocol>| Yes | List of available role groups in your project  |
 
@@ -1061,7 +1061,7 @@ However, if you're viewing an organization's services, you must be a member of a
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   productUiList | List<ProductUiHierarchyProtocol>| Yes  | Homepage Category Service UI List |
 
 ##### ProductUiHierarchyProtocol
@@ -1134,7 +1134,7 @@ However, if you're viewing an organization's services, you must be a member of a
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   hasUpdateSecretKeyPermission | Boolean| Yes | Permission to reissue secret keys  |
 |   product | ProjectProductRelationAndProductProtocol| Yes  | Returns information about the services being used by the project for the specified service ID, not including on error |
 
@@ -1227,7 +1227,7 @@ API to get a specific member of a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   projectMember | ProjectMemberRoleBundleProtocol| Yes  | Added member information, not included on error |
 
 
@@ -1317,7 +1317,7 @@ API for getting a list of members belonging to a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List<ProjectMemberProtocol>| Yes | Project members  |
 
@@ -1403,7 +1403,7 @@ API to get a project's role groups.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   roleGroup | RoleGroupBundleProtocol| Yes | Role groups with related roles  |
 
 ##### RoleGroupBundleProtocol
@@ -1483,7 +1483,7 @@ API to get project common role groups.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | Role groups with related roles  |
 
 
@@ -1544,7 +1544,7 @@ API to get all role groups in a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes  |
+|   header | [Common response](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List<[RoleGroupProtocol](#rolegroupprotocol)>| Yes | List of available role groups in your project  |
 
@@ -1606,7 +1606,7 @@ Members of an organization
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse) | Yes |
 |   projectList | List<OrgProjectMemberRoleProtocol>| Yes |
 
@@ -1670,7 +1670,7 @@ API to get the active governance.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   usingGovernances | List<GovernanceProtocol>| No | List governance in use  |
 
 
@@ -1741,7 +1741,7 @@ API to create project common role groups.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 
 <a id="delete-a-project-common-role-group-in-the-organization"></a>
@@ -1790,7 +1790,7 @@ API to delete a project common role group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-role-group-information"></a>
 ### Modify your organization's project common role group information { #modify-your-organizations-project-common-role-group-information }
@@ -1841,7 +1841,7 @@ API to modify the name and description of a project's common role group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-roles-group-roles"></a>
 ### Modify your organization's project common roles group roles { #modify-your-organizations-project-common-roles-group-roles }
@@ -1891,7 +1891,7 @@ API to modify roles in the project common roles group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="create-a-project-role-group"></a>
 ### Create a project role group { #create-a-project-role-group }
@@ -1935,7 +1935,7 @@ API to create role groups in your project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="delete-a-project-role-group"></a>
 ### Delete a project role group { #delete-a-project-role-group }
@@ -1979,7 +1979,7 @@ API to delete a project role group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="edit-project-role-group-information"></a>
 ### Edit project role group information { #edit-project-role-group-information }
@@ -2022,7 +2022,7 @@ API to modify the name and description of a project role group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 
 <a id="modify-project-role-group-roles"></a>
@@ -2073,7 +2073,7 @@ API to modify roles in the project role group.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 
 <a id="view-all-organization-role-groups"></a>
@@ -2130,7 +2130,7 @@ An API to view all organization role groups.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | --------- | ------------ |
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse) | Yes | |
 | roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)> | Yes | List of role groups available in your organization |
 
@@ -2202,7 +2202,7 @@ An API to view an organization's role group.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | --------- | ------------ |
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 | roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | Role group with associated roles |
 
 <a id="create-organization-role-group"></a>
@@ -2242,7 +2242,7 @@ An API to create a role group in the organization.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 
 <a id="delete-organization-role-group"></a>
 ### Delete Organization Role Group { #delete-organization-role-group }
@@ -2281,7 +2281,7 @@ An API to delete organization role groups.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 
 <a id="modify-organization-role-group-information"></a>
 ### Modify Organization Role Group Information { #modify-organization-role-group-information }
@@ -2321,7 +2321,7 @@ An API to modify the name and description of an organization role group.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [Common Response](#Response)| Yes | |
+| header | [Common Response](#common-response)| Yes | |
 
 
 <a id="modify-an-organization-role-groups-role"></a>
@@ -2368,7 +2368,7 @@ An API to modify roles in an organization role group.
 
 | Name | Type | Required | Description |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 
 
 <a id="modify-organization-member-roles"></a>
@@ -2423,7 +2423,7 @@ API to modify the roles of members who belong to this organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="modify-project-member-roles"></a>
 ### Modify project member roles { #modify-project-member-roles }
@@ -2465,7 +2465,7 @@ API to modify the role of a specified member in a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="view-organization-iam-members"></a>
 ### View organization IAM members { #view-organization-iam-members }
@@ -2558,7 +2558,7 @@ API to get the IAM members in your organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   orgMember | OrgIamMemberRoleBundleProtocol| No  |
 
 ##### OrgIamMemberRoleBundleProtocol
@@ -2691,7 +2691,7 @@ API to get a list of IAM members that belong to this organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   orgMembers | List<IamOrgMemberProtocol>| No | Organization IAM member list  |
 |   paging | [PagingResponse](#pagingresponse)| No  |
 
@@ -2804,7 +2804,7 @@ API to add IAM members to your organization.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   UUID | String| No | IAM member UUID  |
 
 
@@ -2859,7 +2859,7 @@ API to send an email to an IAM member to change their password.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="modify-organization-iam-member-information"></a>
 ### Modify organization IAM member information { #modify-organization-iam-member-information }
@@ -2931,7 +2931,7 @@ API to modify your organization's IAM member information.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="change-an-organization-iam-member-password"></a>
 ### Change an organization IAM member password { #change-an-organization-iam-member-password }
@@ -2979,7 +2979,7 @@ API to change the password of an organization IAM member.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="listorganization-ip-acls"></a>
 ### Listorganization IP ACLs { #listorganization-ip-acls }
@@ -3022,7 +3022,7 @@ API to get IP ACL settings.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   orgIpAcl | List<OrgIpAclProtocol>| Yes  | If the result is an empty list, the setting is not set. |
 
 ##### OrgIpAclProtocol
@@ -3079,7 +3079,7 @@ API to get login session settings information.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [Common response](#Response)| Yes   |
+| header | [Common response](#common-response)| Yes   |
 | result | Content | Yes | Setup contents |
 
 ##### Content
@@ -3153,7 +3153,7 @@ API to get settings for login two-factor authentication.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   result | Result| No |  Response content<br>If never set, null is returned |
 
 ##### Result
@@ -3232,7 +3232,7 @@ API to get login failure security settings.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [Common response](#Response)| Yes   |
+| header | [Common response](#common-response)| Yes   |
 | result | Result | No | Returned only if login failure security is set, otherwise null is returned |
 
 ##### Result
@@ -3312,7 +3312,7 @@ API to get settings for password policies.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [Common response](#response)| Yes   |
+| header | [Common response](#common-response)| Yes   |
 | result | Content | Yes | Setup contents |
 
 ##### Content
@@ -3434,7 +3434,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   paging | PagingResponse| Yes | Return paging results with no sorting criteria  |
 |   prices | List<ContractProductPriceProtocol>| Yes | Returns unit price information from counters as an array<br>Not included on error  |
 
@@ -3534,7 +3534,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   products | List<ProductMetadata>| Yes | Service meta information list  |
 
@@ -3613,7 +3613,7 @@ API to get a list of project integrated AppKeys being used by the project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   authenticationList | List<ProjectAppKeyResponse>| No | Project integrated AppKey List |
 
 ##### ProjectAppKeyResponse
@@ -3674,7 +3674,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   authentications | List<UserAccessKeyResponse>| No | List credentials  |
 
 ##### UserAccessKeyResponse
@@ -3744,7 +3744,7 @@ API to generate an AppKey for use in your project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3806,7 +3806,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3859,7 +3859,7 @@ API to delete a project AppKey.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 
 <a id="reissue-the-user-access-key-id-secret-key"></a>
@@ -3910,7 +3910,7 @@ Can only reissue the secret key for the user's own User Access Key ID
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3966,7 +3966,7 @@ Can only modify the user's own User Access Key ID
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#Response)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 <a id="delete-a-user-access-key-id"></a>
 ### Delete a User Access Key ID { #delete-a-user-access-key-id }
@@ -4005,7 +4005,7 @@ Can only delete the user's own User Access Key ID
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#응답)| Yes |
+|   header | [Common response](#common-response)| Yes |
 
 
 <a id="get-a-list-of-tokens"></a>
@@ -4064,7 +4064,7 @@ Only tokens issued with your own User Access Key ID can be viewed
 
 | Name | Type           | Required  | Description                 |   
 |------------ |--------------|-----|--------------------|
-|   header | [Common response](#응답) | Yes |
+|   header | [Common response](#common-response) | Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   accessToken | String       | Yes | Masked token         |
 |   expireDatetime | Date         | No  | Token expiration date             |
@@ -4115,7 +4115,7 @@ Only tokens issued with your own User Access Key ID can expire
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#Response)| Yes |
+|   header | [Common response](#common-response)| Yes |
 
 
 <a id="create-a-project-iam-account"></a>
@@ -4192,7 +4192,7 @@ API to add an IAM account as a project member.
 
 | Name | Type           | Required | Description |   
 |------------ |--------------| ------- | ------------ |
-|   header | [Common response](#응답) | Yes |
+|   header | [Common response](#common-response) | Yes |
 
 
 <a id="delete-multiple-project-iam-accounts"></a>
@@ -4243,7 +4243,7 @@ API to delete IAM accounts from a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#응답)| Yes |
+|   header | [Common response](#common-response)| Yes |
 
 
 <a id="view-a-project-iam-account"></a>
@@ -4314,7 +4314,7 @@ API to get a specific IAM account who is part of a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#응답)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   projectMember | ProjectIamMemberRoleBundleProtocol| Yes  | Added member information, not included on error |
 
 
@@ -4396,7 +4396,7 @@ API to get a list of IAM accounts who are part of a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#응답)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List<IamProjectMemberProtocol>| Yes | Project member list  |
 
@@ -4459,7 +4459,7 @@ API to change the role of a specified IAM account in a project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [Common response](#응답)| Yes   |
+|   header | [Common response](#common-response)| Yes   |
 
 
 <a id="view-all-credentials-of-members-under-organizations"></a>
@@ -4526,7 +4526,7 @@ API to get the credentials of members in the organization or project.
 
 | Name | Type | Required | Description |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [Common response](#응답)| Yes |
+|   header | [Common response](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   authenticationList | List<UserAccessKeyResponseV7>| Yes  | Member-specific authentication key information |
 
@@ -4616,7 +4616,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| header | [Common response](#response) | Yes | |
+| header | [Common response](#common-response) | Yes | |
 | orgList | List&lt;OrgMemberRelationProtocol> | Yes | Organization lilst info |
 | paging | [PagingResponse](#pagingresponse) | Yes | Paging info |
 
@@ -4717,7 +4717,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| header | [Common response](#response) | Yes | |
+| header | [Common response](#common-response) | Yes | |
 | orgId | String | Yes | Organization ID |
 | orgName | String | Yes | Organization name |
 | owner | [Owner](#owner) | Yes | Organization Owner info |
@@ -4767,7 +4767,7 @@ An API to delete your own organization.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| header | [Common Response](#Response) | Yes | |
+| header | [Common Response](#common-response) | Yes | |
 
 <a id="retrieve-service-information-list"></a>
 ### Retrieve Service Information List { #retrieve-service-information-list }
@@ -4822,7 +4822,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| header | [common response](#response) | Yes | |
+| header | [common response](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse) | Yes | |
 | products | List<Product> | Yes | Service Information List |
 
@@ -4895,7 +4895,7 @@ Available to all members. No specific permissions required.
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| Header | [Common Response](#Response) | Yes | |
+| Header | [Common Response](#common-response) | Yes | |
 | Messages | List<MessageProtocol> | Yes | Message list |
 | Paging | [PagingResponse](#pagingresponse)| Yes | |
 

--- a/ja/public-api/framework-api.md
+++ b/ja/public-api/framework-api.md
@@ -69,75 +69,75 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | メソッド | HTTPリクエスト | 説明 |
 |------------- | ------------- | -------------|
-| POST |[/v1/projects/{project-id}/members](#プロジェクト-メンバー-作成) | プロジェクトメンバー作成 |
-| POST |[/v1/organizations/{org-id}/projects](#プロジェクト-追加) | プロジェクト追加 |
-| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#プロジェクト-メンバー-単件-削除) | プロジェクトメンバー単件削除 |
-| DELETE |[/v1/projects/{project-id}](#プロジェクト-削除) | プロジェクト削除 |
-| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#プロジェクト-サービス-終了) | プロジェクトサービス終了 |
-| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#プロジェクト-サービス-利用) | プロジェクトサービス利用 |
-| GET |[/v1/organizations/{org-id}/roles](#組織-ロール-リスト-照会) | 組織ロールリスト照会 |
-| GET |[/v1/projects/{project-id}/roles](#プロジェクト-ロール-リスト-照会) | プロジェクトロールリスト照会 |
-| GET |[/v1/organizations/{org-id}/domains](#組織-ドメイン-検索) | 組織ドメイン検索 |
-| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#組織-メンバー-単件-照会) | 組織メンバー単件照会 |
-| POST |[/v1/organizations/{org-id}/members/search](#組織-メンバー-リスト-照会) | 組織メンバーリスト照会 |
-| GET |[/v1/organizations/{org-id}/project-role-groups](#組織の-プロジェクト-共通-ロール-グループ-全体-照会) | 組織のプロジェクト共通ロールグループ全体照会 |
-| GET |[/v1/product-uis/hierarchy](#サービス-階層-構造-照会) | サービス階層構造照会 |
-| GET |[/v1/projects/{project-id}/products/{product-id}](#プロジェクトで-使用-中の-サービス-照会) | プロジェクトで使用中のサービス照会 |
-| GET |[/v1/projects/{project-id}/members/{member-uuid}](#プロジェクト-メンバー-単件-照会) | プロジェクトメンバー単件照会 |
-| POST |[/v1/projects/{project-id}/members/search](#プロジェクト-メンバー-リスト-照会) | プロジェクトメンバーリスト照会 |
-| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#プロジェクト-ロール-グループ-単件-照会) | プロジェクトロールグループ単件照会 |
-| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#組織の-プロジェクト-共通-ロール-グループ-単件-照会) | 組織のプロジェクト共通ロールグループ単件照会 |
-| GET |[/v1/projects/{project-id}/project-role-groups](#プロジェクト-ロール-グループ-全体-照会) | プロジェクトロールグループ全体照会 |
-| GET |[/v1/organizations/{org-id}/projects](#組織に-属する-プロジェクト-リスト-照会) | 組織に属するプロジェクトリスト照会 |
-| GET |[/v1/organizations/{org-id}/governances](#使用-中の-組織-ガバナンス-リスト-照会) | 使用中の組織ガバナンスリスト照会 |
-| POST |[/v1/organizations/{org-id}/project-role-groups](#組織の-プロジェクト-共通-ロール-グループ-作成) | 組織のプロジェクト共通ロールグループ作成 |
-| DELETE |[/v1/organizations/{org-id}/project-role-groups](#組織の-プロジェクト-共通-ロール-グループ-削除) | 組織のプロジェクト共通ロールグループ削除 |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#組織の-プロジェクト-共通-ロール-グループ-情報-修正) | 組織のプロジェクト共通ロールグループ情報修正 |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#組織の-プロジェクト-共通-ロール-グループ-ロール-修正) | 組織のプロジェクト共通ロールグループロール修正 |
-| POST |[/v1/projects/{project-id}/project-role-groups](#プロジェクト-ロール-グループ-作成) | プロジェクトロールグループ作成 |
-| DELETE |[/v1/projects/{project-id}/project-role-groups](#プロジェクト-ロール-グループ-削除) | プロジェクトロールグループ削除 |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#プロジェクト-ロール-グループ-情報-修正) | プロジェクトロールグループ情報修正 |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#プロジェクト-ロール-グループ-ロール-修正) | プロジェクトロールグループロール修正 |
+| POST |[/v1/projects/{project-id}/members](#create-a-project-member) | プロジェクトメンバー作成 |
+| POST |[/v1/organizations/{org-id}/projects](#add-a-project) | プロジェクト追加 |
+| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#delete-a-single-project-member) | プロジェクトメンバー単件削除 |
+| DELETE |[/v1/projects/{project-id}](#delete-a-project) | プロジェクト削除 |
+| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#end-a-project-service) | プロジェクトサービス終了 |
+| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#use-a-service-product) | プロジェクトサービス利用 |
+| GET |[/v1/organizations/{org-id}/roles](#list-organization-roles) | 組織ロールリスト照会 |
+| GET |[/v1/projects/{project-id}/roles](#list-project-roles) | プロジェクトロールリスト照会 |
+| GET |[/v1/organizations/{org-id}/domains](#search-for-an-organization-domain) | 組織ドメイン検索 |
+| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#view-a-organization-member) | 組織メンバー単件照会 |
+| POST |[/v1/organizations/{org-id}/members/search](#list-organization-members) | 組織メンバーリスト照会 |
+| GET |[/v1/organizations/{org-id}/project-role-groups](#view-all-common-role-groups-for-projects-in-the-organization) | 組織のプロジェクト共通ロールグループ全体照会 |
+| GET |[/v1/product-uis/hierarchy](#view-service-hierarchy) | サービス階層構造照会 |
+| GET |[/v1/projects/{project-id}/products/{product-id}](#view-a-service-used-in-the-project) | プロジェクトで使用中のサービス照会 |
+| GET |[/v1/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | プロジェクトメンバー単件照会 |
+| POST |[/v1/projects/{project-id}/members/search](#list-project-members) | プロジェクトメンバーリスト照会 |
+| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#view-a-project-role-group) | プロジェクトロールグループ単件照会 |
+| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#view-a-common-role-group-for-the-project-in-the-organization) | 組織のプロジェクト共通ロールグループ単件照会 |
+| GET |[/v1/projects/{project-id}/project-role-groups](#view-all-project-role-groups) | プロジェクトロールグループ全体照会 |
+| GET |[/v1/organizations/{org-id}/projects](#list-projects-in-your-organization) | 組織に属するプロジェクトリスト照会 |
+| GET |[/v1/organizations/{org-id}/governances](#list-organization-governance-in-use) | 使用中の組織ガバナンスリスト照会 |
+| POST |[/v1/organizations/{org-id}/project-role-groups](#create-a-common-role-group-for-projects-in-the-organization) | 組織のプロジェクト共通ロールグループ作成 |
+| DELETE |[/v1/organizations/{org-id}/project-role-groups](#delete-a-project-common-role-group-in-the-organization) | 組織のプロジェクト共通ロールグループ削除 |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#modify-your-organizations-project-common-role-group-information) | 組織のプロジェクト共通ロールグループ情報修正 |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#modify-your-organizations-project-common-roles-group-roles) | 組織のプロジェクト共通ロールグループロール修正 |
+| POST |[/v1/projects/{project-id}/project-role-groups](#create-a-project-role-group) | プロジェクトロールグループ作成 |
+| DELETE |[/v1/projects/{project-id}/project-role-groups](#delete-a-project-role-group) | プロジェクトロールグループ削除 |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#edit-project-role-group-information) | プロジェクトロールグループ情報修正 |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#modify-project-role-group-roles) | プロジェクトロールグループロール修正 |
 | GET |[/v1/organizations/{org-id}/org-role-groups](#組織-ロール-グループ-全体-照会) | 組織ロールグループ全体照会 |
 | GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#組織-ロール-グループ-単件-照会) | 組織ロールグループ単件照会 |
-| POST |[/v1/organizations/{org-id}/org-role-groups](#組織-ロール-グループ-作成) | 組織ロールグループ作成 |
-| DELETE |[/v1/organizations/{org-id}/org-role-groups](#組織-ロール-グループ-削除) | 組織ロールグループ削除 |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#組織-ロール-グループ-情報-修正) | 組織ロールグループ情報修正 |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#組織-ロール-グループ-ロール-修正) | 組織ロールグループロール修正 |
-| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#組織-メンバー-ロール-修正) | 組織メンバーロール修正 |
-| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#プロジェクト-メンバー-ロール-修正) | プロジェクトメンバーロール修正 |
-| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#組織-IAM-メンバー-単件-照会) | 組織IAMメンバー単件照会 |
-| GET |[/v1/iam/organizations/{org-id}/members](#組織-IAM-メンバー-リスト-照会) | 組織IAMメンバーリスト照会 |
-| POST |[/v1/iam/organizations/{org-id}/members](#組織-IAM-メンバー-追加) | 組織IAMメンバー追加 |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#IAM-メンバー-パスワード-変更-メール-送信) | IAMメンバーパスワード変更メール送信 |
-| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#組織-IAM-メンバー-情報-修正) | 組織IAMメンバー情報修正 |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#組織-IAM-メンバー-パスワード-変更) | 組織IAMメンバーパスワード変更 |
-| GET |[/v1/iam/organizations/{org-id}/settings/session](#組織-IAM-ログイン-セッション-設定-情報を-照会) | 組織IAMログインセッション設定情報を照会 |
+| POST |[/v1/organizations/{org-id}/org-role-groups](#create-organization-role-group) | 組織ロールグループ作成 |
+| DELETE |[/v1/organizations/{org-id}/org-role-groups](#delete-organization-role-group) | 組織ロールグループ削除 |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#modify-organization-role-group-information) | 組織ロールグループ情報修正 |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#modify-an-organization-role-groups-role) | 組織ロールグループロール修正 |
+| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#modify-organization-member-roles) | 組織メンバーロール修正 |
+| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#modify-project-member-roles) | プロジェクトメンバーロール修正 |
+| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#view-organization-iam-members) | 組織IAMメンバー単件照会 |
+| GET |[/v1/iam/organizations/{org-id}/members](#list-organization-iam-members) | 組織IAMメンバーリスト照会 |
+| POST |[/v1/iam/organizations/{org-id}/members](#add-an-organization-iam-member) | 組織IAMメンバー追加 |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#send-an-iam-member-password-change-email) | IAMメンバーパスワード変更メール送信 |
+| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#modify-organization-iam-member-information) | 組織IAMメンバー情報修正 |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#change-an-organization-iam-member-password) | 組織IAMメンバーパスワード変更 |
+| GET |[/v1/iam/organizations/{org-id}/settings/session](#view-organization-iam-sign-in-session-settings-information) | 組織IAMログインセッション設定情報を照会 |
 | GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#組織-IAM-ログイン-2次-認証-の-設定を-照会) | 組織IAMログイン2段階認証の設定を照会 |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#組織-IAM-ログイン-失敗-セキュリティ-設定を-照会) | 組織IAMログイン失敗セキュリティ設定を照会 |
-| GET |[/v1/organizations/{org-id}/products/ip-acl](#組織-IP-ACL-リスト-照会) | 組織IP ACLリスト照会 |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#view-organization-iam-login-failure-security-settings) | 組織IAMログイン失敗セキュリティ設定を照会 |
+| GET |[/v1/organizations/{org-id}/products/ip-acl](#listorganization-ip-acls) | 組織IP ACLリスト照会 |
 | POST |[/v1/billing/contracts/basic/products/prices/search](#従量制に-登録された-サービス-価格-照会) | 従量制に登録されたサービス価格照会 |
-| GET |[/v1/billing/contracts/basic/products](#従量制に-登録された-サービス-リスト-照会) | 従量制に登録されたサービスリスト照会 |
-| GET |[/v1/authentications/projects/{project-id}/project-appkeys](#プロジェクト-統合-Appkey-照会) | プロジェクト統合-Appkey照会 |
-| GET |[/v1/authentications/user-access-keys](#User-Access-Key-ID-リスト-照会) | User Access Key IDリスト照会 |
-| POST |[/v1/authentications/projects/{project-id}/project-appkeys](#プロジェクト-統合-Appkey-登録) | プロジェクト統合-Appkey登録 |
-| POST |[/v1/authentications/user-access-keys](#User-Access-Key-ID-登録) | User Access Key ID登録 |
-| DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#プロジェクト-統合-Appkey-削除) | プロジェクト統合-Appkey削除 |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#User-Access-Key-ID-秘密-鍵-再発行) | User Access Key ID秘密鍵の再発行 |
+| GET |[/v1/billing/contracts/basic/products](#list-services-enrolled-in-a-pay-as-you-go-subscription) | 従量制に登録されたサービスリスト照会 |
+| GET |[/v1/authentications/projects/{project-id}/project-appkeys](#get-project-integrated-appkey) | プロジェクト統合-Appkey照会 |
+| GET |[/v1/authentications/user-access-keys](#listuser-access-key-ids) | User Access Key IDリスト照会 |
+| POST |[/v1/authentications/projects/{project-id}/project-appkeys](#register-a-integrated-project-appkey) | プロジェクト統合-Appkey登録 |
+| POST |[/v1/authentications/user-access-keys](#register-a-user-access-key-id) | User Access Key ID登録 |
+| DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#delete-a-project-integrated-appkey) | プロジェクト統合-Appkey削除 |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#reissue-the-user-access-key-id-secret-key) | User Access Key ID秘密鍵の再発行 |
 | PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-状態-修正) | User Access Key ID状態修正 |
-| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-削除) | User Access Key ID削除 |
-| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#トークン-リスト-照会)                               | トークンリスト照会                 |
-| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#トークン-複数-期限切れ)                               | トークン複数期限切れ                  |
-| POST |[/v1/iam/projects/{project-id}/members](#プロジェクト-IAM-アカウント-作成) | プロジェクトIAMアカウント作成 |
-| DELETE |[/v1/iam/projects/{project-id}/members](#プロジェクト-IAM-アカウント-一括-削除) | プロジェクトIAMアカウント一括削除 |
-| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#プロジェクト-メンバー-単件-照会) | プロジェクトIAMアカウント単件照会 |
-| GET |[/v1/iam/projects/{project-id}/members](#プロジェクト-IAM-アカウント-リスト-照会) | プロジェクトIAMアカウントリスト照会 |
-| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#プロジェクト-IAM-アカウント-ロール-修正) | プロジェクトIAMアカウントロール修正 |
+| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#delete-a-user-access-key-id) | User Access Key ID削除 |
+| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#get-a-list-of-tokens)                               | トークンリスト照会                 |
+| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#expire-multiple-tokens)                               | トークン複数期限切れ                  |
+| POST |[/v1/iam/projects/{project-id}/members](#create-a-project-iam-account) | プロジェクトIAMアカウント作成 |
+| DELETE |[/v1/iam/projects/{project-id}/members](#delete-multiple-project-iam-accounts) | プロジェクトIAMアカウント一括削除 |
+| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | プロジェクトIAMアカウント単件照会 |
+| GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | プロジェクトIAMアカウントリスト照会 |
+| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | プロジェクトIAMアカウントロール修正 |
 | GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#組織-下位-メンバーの-全ての-認証情報-リスト-照会) | 組織下位メンバー認証情報リスト照会 |
-| GET | [/v1/organizations](#自分の組織一覧の照会) | 自分の組織一覧の照会 |
-| POST | [/v1/organizations](#自分の組織の追加) | 自分の組織の追加 |
-| DELETE | [/v1/organizations/{org-id}](#組織の個別削除) | 組織の個別削除 |
-| GET | [/v1/messages/role](#ロール-説明-多言語-照会) | ロール説明多言語照会 |
+| GET | [/v1/organizations](#view-your-own-organization-list) | 自分の組織一覧の照会 |
+| POST | [/v1/organizations](#add-your-own-organization) | 自分の組織の追加 |
+| DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | 組織の個別削除 |
+| GET | [/v1/messages/role](#view-role-descriptions-by-multiple-language) | ロール説明多言語照会 |
 
 
 <a id="create-a-project-member"></a>
@@ -216,7 +216,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ          | 必須 | 説明 |   
 |------------ |--------------| ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス) | Yes |
+|   header | [共通レスポンス](#common-response) | Yes |
 
 
 <a id="add-a-project"></a>
@@ -274,7 +274,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes  |
+|   header | [共通レスポンス](#common-response)| Yes  |
 |   regDateTime | Date| Yes   | プロジェクト作成日時 | 
 |   description | String| No   | プロジェクトの説明 | 
 |   ownerId | String| Yes   | プロジェクト所有者メンバーID | 
@@ -326,7 +326,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 
 
 
@@ -375,7 +375,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 
 
 
@@ -426,7 +426,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   childProducts | List&lt;ChildProduct>| No   | 該当サービスの下位サービス情報で、下位サービスがない場合は含まれません。<br>下位サービスを先に無効にして、該当サービスを無効化する必要があります。|
 
 ##### ChildProduct
@@ -486,7 +486,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   appKey | String| Yes | 該当プロジェクトで利用中のサービスのアプリキー情報|
 |   parentProduct | ParentProduct| No | 上位サービス情報がある場合はその情報を表示し、上位サービスがない場合は含みません。 |
 |   secretKey | String| No| 該当プロジェクトで利用中のサービスの秘密鍵情報<br> 秘密鍵を利用するサービスでのみ提供 |
@@ -560,7 +560,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   roles | List&lt;RoleProtocol>| Yes  | ロールリスト |
 |   totalCount | Integer| Yes  | 総数 |
 
@@ -629,7 +629,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   roles | List&lt;[RoleProtocol](#roleprotocol)>| Yes  | ロールリスト |
 |   totalCount | Integer| Yes  | 総数 |
 
@@ -680,7 +680,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   domainList | List&lt;OrgDomainProtocol>| Yes  |
 
 
@@ -767,7 +767,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   orgMember | OrgMemberRoleBundleProtocol| No  | 追加されたメンバー情報、エラーの場合は含まれません。 |
 
 ##### OrgMemberRoleBundleProtocol
@@ -894,7 +894,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   orgMembers | List&lt;OrgMemberWithInviteMemberrotocol>| Yes | 組織メンバーリスト |
 |   paging | PagingResponse| Yes | ページ情報 |
 
@@ -987,7 +987,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes  |
+|   header | [共通レスポンス](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List&lt;RoleGroupProtocol>| Yes | プロジェクトで使用可能なロールグループリスト |
 
@@ -1055,7 +1055,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   productUiList | List&lt;ProductUiHierarchyProtocol>| Yes  | WebサイトカテゴリーサービスUIリスト |
 
 ##### ProductUiHierarchyProtocol
@@ -1128,7 +1128,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   hasUpdateSecretKeyPermission | Boolean| Yes | 秘密鍵再発行可能権限 |
 |   product | ProjectProductRelationAndProductProtocol| Yes  | 指定したサービスIDに対して、プロジェクトで使用しているサービス情報を返し、エラー時は含みません。 |
 
@@ -1221,7 +1221,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   projectMember | ProjectMemberRoleBundleProtocol| Yes  | 追加されたメンバー情報、エラー時は含まれません。 |
 
 
@@ -1311,7 +1311,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List&lt;ProjectMemberProtocol>| Yes | プロジェクトメンバー |
 
@@ -1397,7 +1397,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   roleGroup | RoleGroupBundleProtocol| Yes | 関連ロールを含むロールグループ |
 
 ##### RoleGroupBundleProtocol
@@ -1477,7 +1477,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | 関連ロールを含むロールグループ |
 
 
@@ -1538,7 +1538,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes  |
+|   header | [共通レスポンス](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)>| Yes | プロジェクトで使用可能なロールグループリスト |
 
@@ -1600,7 +1600,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse) | Yes |
 |   projectList | List&lt;OrgProjectMemberRoleProtocol>| Yes |
 
@@ -1664,7 +1664,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   usingGovernances | List&lt;GovernanceProtocol>| No | 使用中のガバナンスリスト |
 
 
@@ -1735,7 +1735,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 
 <a id="delete-a-project-common-role-group-in-the-organization"></a>
@@ -1784,7 +1784,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-role-group-information"></a>
 ### 組織のプロジェクト共通ロールグループ情報修正 { #modify-your-organizations-project-common-role-group-information }
@@ -1835,7 +1835,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-roles-group-roles"></a>
 ### 組織のプロジェクト共通ロールグループロール修正 { #modify-your-organizations-project-common-roles-group-roles }
@@ -1885,7 +1885,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="create-a-project-role-group"></a>
 ### プロジェクトロールグループ作成 { #create-a-project-role-group }
@@ -1929,7 +1929,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="delete-a-project-role-group"></a>
 ### プロジェクトロールグループ削除 { #delete-a-project-role-group }
@@ -1973,7 +1973,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="edit-project-role-group-information"></a>
 ### プロジェクトロールグループ情報修正 { #edit-project-role-group-information }
@@ -2016,7 +2016,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 
 <a id="modify-project-role-group-roles"></a>
@@ -2067,7 +2067,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="view-all-organization-role-groups"></a>
 ### 組織ロールグループ全件照会 { #view-all-organization-role-groups }
@@ -2122,7 +2122,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | --------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse) | Yes | |
 | roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)> | Yes | 組織で使用可能なロールグループリスト |
 
@@ -2193,7 +2193,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | --------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | 関連ロールを含むロールグループ |
 
 <a id="create-organization-role-group"></a>
@@ -2232,7 +2232,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 
 <a id="delete-organization-role-group"></a>
 ### 組織ロールグループ削除 { #delete-organization-role-group }
@@ -2270,7 +2270,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 
 <a id="modify-organization-role-group-information"></a>
 ### 組織ロールグループ情報修正 { #modify-organization-role-group-information }
@@ -2309,7 +2309,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 
 
 <a id="modify-an-organization-role-groups-role"></a>
@@ -2355,7 +2355,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 
 
 <a id="modify-organization-member-roles"></a>
@@ -2410,7 +2410,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="modify-project-member-roles"></a>
 ### プロジェクトメンバーロール修正 { #modify-project-member-roles }
@@ -2452,7 +2452,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="view-organization-iam-members"></a>
 ### 組織IAMメンバー単件照会 { #view-organization-iam-members }
@@ -2545,7 +2545,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   orgMember | OrgIamMemberRoleBundleProtocol| No  |
 
 ##### OrgIamMemberRoleBundleProtocol
@@ -2678,7 +2678,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   orgMembers | List&lt;IamOrgMemberProtocol>| No | 組織IAMメンバーリスト |
 |   paging | [PagingResponse](#pagingresponse)| No  |
 
@@ -2791,7 +2791,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   uuid | String| No | IAMメンバーUUID  |
 
 
@@ -2846,7 +2846,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="modify-organization-iam-member-information"></a>
 ### 組織IAMメンバー情報修正 { #modify-organization-iam-member-information }
@@ -2917,7 +2917,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="change-an-organization-iam-member-password"></a>
 ### 組織IAMメンバーパスワード変更 { #change-an-organization-iam-member-password }
@@ -2965,7 +2965,7 @@ IAMメンバーのパスワードを変更できるメールを送信するAPI�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="listorganization-ip-acls"></a>
 ### 組織IP ACLリスト照会 { #listorganization-ip-acls }
@@ -3008,7 +3008,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   orgIpAcl | List&lt;OrgIpAclProtocol>| Yes  | 設定結果、空リストの場合は設定されていない状態 |
 
 ##### OrgIpAclProtocol
@@ -3065,7 +3065,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [共通レスポンス](#レスポンス)| Yes   |
+| header | [共通レスポンス](#common-response)| Yes   |
 | result | Content | Yes | 設定内容 |
 
 ##### Content
@@ -3139,7 +3139,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   result | Result| No | レスポンス内容<br>設定したことがない場合はnullが返されます。 |
 
 ##### Result
@@ -3218,7 +3218,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [共通レスポンス](#レスポンス)| Yes   |
+| header | [共通レスポンス](#common-response)| Yes   |
 | result | Result | No | ログイン失敗セキュリティを設定した場合のみ返され、設定しない場合はnullが返されます。 |
 
 ##### Result
@@ -3360,7 +3360,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   paging | PagingResponse| Yes | ソート基準がないページング結果を返す |
 |   prices | List&lt;ContractProductPriceProtocol>| Yes | カウンターの単価情報を配列で返す<br>エラー時は含まれません。  |
 
@@ -3460,7 +3460,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   products | List&lt;ProductMetadata>| Yes | サービスメタ情報リスト |
 
@@ -3539,7 +3539,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   authenticationList | List&lt;ProjectAppKeyResponse>| No | プロジェクト統合Appkey一覧 |
 
 ##### ProjectAppKeyResponse
@@ -3602,7 +3602,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   authentications | List&lt;UserAccessKeyResponse>| No | 認証情報リスト |
 
 ##### UserAccessKeyResponse
@@ -3671,7 +3671,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3733,7 +3733,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3785,7 +3785,7 @@ IP ACL設定を照会するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 
 <a id="reissue-the-user-access-key-id-secret-key"></a>
@@ -3837,7 +3837,7 @@ OPAQUEトークン用のUser Access Key IDを停止するとOPAQUEトークン�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3891,7 +3891,7 @@ OPAQUEトークン用のUser Access Key IDを停止するとOPAQUEトークン�
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 <a id="delete-a-user-access-key-id"></a>
 ### User Access Key ID削除 { #delete-a-user-access-key-id }
@@ -3930,7 +3930,7 @@ User Access Key IDを削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 
 
 <a id="get-a-list-of-tokens"></a>
@@ -3988,7 +3988,7 @@ User Access Key IDで発行したOPAQUE トークンリストを照会するAPI�
 
 | 名前 | タイプ        | 必須 | 説明              |   
 |------------ |--------------|-----|--------------------|
-|   header | [共通レスポンス](#レスポンス) | Yes |
+|   header | [共通レスポンス](#common-response) | Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   accessToken | String       | Yes | マスキング処理されたトークン      |
 |   expireDatetime | Date         | No  | トークン有効期限           |
@@ -4038,7 +4038,7 @@ JWTトークンを発行したUser Access Key IDでリクエストしても、JW
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 
 
 <a id="create-a-project-iam-account"></a>
@@ -4114,7 +4114,7 @@ IAMアカウントをプロジェクトメンバーとして追加するAPIで�
 
 | 名前 | タイプ         | 必須 | 説明 |   
 |------------ |--------------| ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス) | Yes |
+|   header | [共通レスポンス](#common-response) | Yes |
 
 
 <a id="delete-multiple-project-iam-accounts"></a>
@@ -4164,7 +4164,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 
 
 <a id="view-a-project-iam-account"></a>
@@ -4234,7 +4234,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   projectMember | ProjectIamMemberRoleBundleProtocol| Yes  | 追加されたメンバー情報、エラー時は含まれません。 |
 
 
@@ -4315,7 +4315,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List&lt;IamProjectMemberProtocol>| Yes | プロジェクトメンバーリスト |
 
@@ -4377,7 +4377,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes   |
+|   header | [共通レスポンス](#common-response)| Yes   |
 
 
 <a id="view-all-credentials-of-members-under-organizations"></a>
@@ -4443,7 +4443,7 @@ IAMアカウントを該当プロジェクトから削除するAPIです。
 
 | 名前 | タイプ | 必須 | 説明 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [共通レスポンス](#レスポンス)| Yes |
+|   header | [共通レスポンス](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   authenticationList | List&lt;UserAccessKeyResponseV7>| Yes  | メンバーごとの認証キー情報 |
 
@@ -4536,7 +4536,7 @@ GET /v1/organizations
 
 | 名前 | 型 | 必須 | 説明 |
 |---|---|---|---|
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | orgList | List&lt;OrgMemberRelationProtocol> | Yes | 組織一覧情報 |
 | paging | [PagingResponse](#pagingresponse) | Yes | ページング情報 |
 
@@ -4636,7 +4636,7 @@ GET /v1/organizations
 
 | 名前 | 型 | 必須 | 説明 |
 |---|---|---|---|
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | orgId | String | Yes | 組織ID |
 | orgName | String | Yes | 組織名 |
 | owner | [Owner](#owner) | Yes | 組織オーナー情報 |
@@ -4686,7 +4686,7 @@ GET /v1/organizations
 
 | 名前 | 型 | 必須 | 説明 |
 |---|---|---|---|
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 
 
 <a id="retrieve-service-information-list"></a>
@@ -4743,7 +4743,7 @@ GET /v1/organizations
 
 | 名前 | 型 | 必須 | 説明 |
 |---|---|---|---|
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse)| Yes | |
 | products | List&lt;Product> | Yes | サービス情報一覧 |
 
@@ -4816,7 +4816,7 @@ GET /v1/organizations
 
 | 名前 | タイプ | 必須 | 説明 |
 |---|---|---|---|
-| header | [共通レスポンス](#レスポンス) | Yes | |
+| header | [共通レスポンス](#common-response) | Yes | |
 | messages | List&lt;MessageProtocol> | Yes | メッセージリスト |
 | paging | [PagingResponse](#pagingresponse)| Yes | |
 

--- a/ko/public-api/framework-api.md
+++ b/ko/public-api/framework-api.md
@@ -73,77 +73,77 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 메서드 | HTTP 요청 | 설명 |
 |------------- | ------------- | -------------|
-| POST |[/v1/projects/{project-id}/members](#프로젝트-멤버-생성) | 프로젝트 멤버 생성 |
-| POST |[/v1/organizations/{org-id}/projects](#프로젝트-추가) | 프로젝트 추가 |
-| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#프로젝트-멤버-단건-삭제) | 프로젝트 멤버 단건 삭제 |
-| DELETE |[/v1/projects/{project-id}](#프로젝트-삭제) | 프로젝트 삭제 |
-| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#프로젝트-서비스-종료) | 프로젝트 서비스 종료 |
-| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#프로젝트-서비스-이용) | 프로젝트 서비스 이용 |
-| GET |[/v1/organizations/{org-id}/roles](#조직-역할-목록-조회) | 조직 역할 목록 조회 |
-| GET |[/v1/projects/{project-id}/roles](#프로젝트-역할-목록-조회) | 프로젝트 역할 목록 조회 |
-| GET |[/v1/organizations/{org-id}/domains](#조직-도메인-검색) | 조직 도메인 검색 |
-| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#조직-멤버-단건-조회) | 조직 멤버 단건 조회 |
-| POST |[/v1/organizations/{org-id}/members/search](#조직-멤버-목록-조회) | 조직 멤버 목록 조회 |
-| GET |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-전체-조회) | 조직의 프로젝트 공통 역할 그룹 전체 조회 |
-| GET |[/v1/product-uis/hierarchy](#서비스-계층-구조-조회) | 서비스 계층 구조 조회 |
-| GET |[/v1/projects/{project-id}/products/{product-id}](#프로젝트에서-사용-중인-서비스-조회) | 프로젝트에서 사용 중인 서비스 조회 |
-| GET |[/v1/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-단건-조회) | 프로젝트 멤버 단건 조회 |
-| POST |[/v1/projects/{project-id}/members/search](#프로젝트-멤버-목록-조회) | 프로젝트 멤버 목록 조회 |
-| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#프로젝트-역할-그룹-단건-조회) | 프로젝트 역할 그룹 단건 조회 |
-| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#조직의-프로젝트-공통-역할-그룹-단건-조회) | 조직의 프로젝트 공통 역할 그룹 단건 조회 |
-| GET |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-전체-조회) | 프로젝트 역할 그룹 전체 조회 |
-| GET |[/v1/organizations/{org-id}/projects](#조직에-속한-프로젝트-목록-조회) | 조직에 속한 프로젝트 목록 조회 |
-| GET |[/v1/organizations/{org-id}/governances](#사용-중인-조직-거버넌스-목록-조회) | 사용 중인 조직 거버넌스 목록 조회 |
-| POST |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-생성) | 조직의 프로젝트 공통 역할 그룹 생성 |
-| DELETE |[/v1/organizations/{org-id}/project-role-groups](#조직의-프로젝트-공통-역할-그룹-삭제) | 조직의 프로젝트 공통 역할 그룹 삭제 |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#조직의-프로젝트-공통-역할-그룹-정보-수정) | 조직의 프로젝트 공통 역할 그룹 정보 수정 |
-| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#조직의-프로젝트-공통-역할-그룹-역할-수정) | 조직의 프로젝트 공통 역할 그룹 역할 수정 |
-| POST |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-생성) | 프로젝트 역할 그룹 생성 |
-| DELETE |[/v1/projects/{project-id}/project-role-groups](#프로젝트-역할-그룹-삭제) | 프로젝트 역할 그룹 삭제 |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#프로젝트-역할-그룹-정보-수정) | 프로젝트 역할 그룹 정보 수정 |
-| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#프로젝트-역할-그룹-역할-수정) | 프로젝트 역할 그룹 역할 수정 |
-| GET |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-전체-조회) | 조직 역할 그룹 전체 조회 |
-| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#조직-역할-그룹-단건-조회) | 조직 역할 그룹 단건 조회 |
-| POST |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-생성) | 조직 역할 그룹 생성 |
-| DELETE |[/v1/organizations/{org-id}/org-role-groups](#조직-역할-그룹-삭제) | 조직 역할 그룹 삭제 |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#조직-역할-그룹-정보-수정) | 조직 역할 그룹 정보 수정 |
-| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#조직-역할-그룹-역할-수정) | 조직 역할 그룹 역할 수정 |
-| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#조직-멤버-역할-수정) | 조직 멤버 역할 수정 |
-| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-역할-수정) | 프로젝트 멤버 역할 수정 |
-| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#조직-IAM-계정-단건-조회) | 조직 IAM 계정 단건 조회 |
-| GET |[/v1/iam/organizations/{org-id}/members](#조직-IAM-계정-목록-조회) | 조직 IAM 계정 목록 조회 |
-| POST |[/v1/iam/organizations/{org-id}/members](#조직-IAM-계정-추가) | 조직 IAM 계정 추가 |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#IAM-계정-비밀번호-변경-이메일-전송) | IAM 계정 비밀번호 변경 이메일 전송 |
-| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#조직-IAM-계정-정보-수정) | 조직 IAM 계정 정보 수정 |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#조직-IAM-계정-비밀번호-변경) | 조직 IAM 계정 비밀번호 변경 |
-| GET |[/v1/iam/organizations/{org-id}/settings/session](#조직-IAM-계정-로그인-세션-설정-정보를-조회) | 조직 IAM 계정 로그인 세션 설정 정보를 조회 |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#조직-IAM-계정-로그인-2차-인증에-대한-설정을-조회) | 조직 IAM 계정 로그인 2차 인증에 대한 설정을 조회 |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#조직-IAM-계정-로그인-실패-보안-설정을-조회) | 조직 IAM 계정 로그인 실패 보안 설정을 조회 |
-| GET |[/v1/iam/organizations/{org-id}/settings/password-rule](#조직-IAM-계정-비밀번호-정책-조회) | 조직 IAM 계정 비밀번호 정책 조회 |
-| GET |[/v1/organizations/{org-id}/products/ip-acl](#조직-IP-ACL-목록-조회) | 조직 IP ACL 목록 조회 |
-| POST |[/v1/billing/contracts/basic/products/prices/search](#종량제에-등록된-서비스-가격-조회) | 종량제에 등록된 서비스 가격 조회 |
-| GET |[/v1/billing/contracts/basic/products](#종량제에-등록된-서비스-목록-조회) | 종량제에 등록된 서비스 목록 조회 |
-| GET | [/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-통합-Appkey-조회) | 프로젝트 통합 Appkey 조회 |
-| GET |[/v1/authentications/user-access-keys](#User-Access-Key-ID-목록-조회) | User Access Key ID 목록 조회 |
-| POST | [/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-통합-Appkey-등록) | 프로젝트 통합 Appkey 등록 |
-| POST |[/v1/authentications/user-access-keys](#User-Access-Key-ID-등록) | User Access Key ID 등록 |
-| DELETE | [/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#프로젝트-통합-Appkey-삭제) | 프로젝트 통합 Appkey 삭제 |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#User-Access-Key-ID-비밀-키-재발급) | User Access Key ID 비밀 키 재발급 |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-상태-수정) | User Access Key ID 상태 수정 |
-| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-삭제) | User Access Key ID 삭제 |
-| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#토큰-목록-조회) | 토큰 목록 조회 |
-| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#토큰-다건-만료) | 토큰 다건 만료 |
-| POST |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-생성) | 프로젝트 IAM 계정 생성 |
-| DELETE |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-다건-삭제) | 프로젝트 IAM 계정 다건 삭제 |
-| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#프로젝트-멤버-단건-조회) | 프로젝트 IAM 계정 단건 조회 |
-| GET |[/v1/iam/projects/{project-id}/members](#프로젝트-IAM-계정-목록-조회) | 프로젝트 IAM 계정 목록 조회 |
-| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#프로젝트-IAM-계정-역할-수정) | 프로젝트 IAM 계정 역할 수정 |
+| POST |[/v1/projects/{project-id}/members](#create-a-project-member) | 프로젝트 멤버 생성 |
+| POST |[/v1/organizations/{org-id}/projects](#add-a-project) | 프로젝트 추가 |
+| DELETE |[/v1/projects/{project-id}/members/{target-uuid}](#delete-a-single-project-member) | 프로젝트 멤버 단건 삭제 |
+| DELETE |[/v1/projects/{project-id}](#delete-a-project) | 프로젝트 삭제 |
+| DELETE |[/v1/projects/{project-id}/products/{product-id}/disable](#end-a-project-service) | 프로젝트 서비스 종료 |
+| POST |[/v1/projects/{project-id}/products/{product-id}/enable](#use-a-service-product) | 프로젝트 서비스 이용 |
+| GET |[/v1/organizations/{org-id}/roles](#list-organization-roles) | 조직 역할 목록 조회 |
+| GET |[/v1/projects/{project-id}/roles](#list-project-roles) | 프로젝트 역할 목록 조회 |
+| GET |[/v1/organizations/{org-id}/domains](#search-for-an-organization-domain) | 조직 도메인 검색 |
+| GET |[/v1/organizations/{org-id}/members/{member-uuid}](#view-a-organization-member) | 조직 멤버 단건 조회 |
+| POST |[/v1/organizations/{org-id}/members/search](#list-organization-members) | 조직 멤버 목록 조회 |
+| GET |[/v1/organizations/{org-id}/project-role-groups](#view-all-common-role-groups-for-projects-in-the-organization) | 조직의 프로젝트 공통 역할 그룹 전체 조회 |
+| GET |[/v1/product-uis/hierarchy](#view-service-hierarchy) | 서비스 계층 구조 조회 |
+| GET |[/v1/projects/{project-id}/products/{product-id}](#view-a-service-used-in-the-project) | 프로젝트에서 사용 중인 서비스 조회 |
+| GET |[/v1/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | 프로젝트 멤버 단건 조회 |
+| POST |[/v1/projects/{project-id}/members/search](#list-project-members) | 프로젝트 멤버 목록 조회 |
+| GET |[/v1/projects/{project-id}/project-role-groups/{role-group-id}](#view-a-project-role-group) | 프로젝트 역할 그룹 단건 조회 |
+| GET |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}](#view-a-common-role-group-for-the-project-in-the-organization) | 조직의 프로젝트 공통 역할 그룹 단건 조회 |
+| GET |[/v1/projects/{project-id}/project-role-groups](#view-all-project-role-groups) | 프로젝트 역할 그룹 전체 조회 |
+| GET |[/v1/organizations/{org-id}/projects](#list-projects-in-your-organization) | 조직에 속한 프로젝트 목록 조회 |
+| GET |[/v1/organizations/{org-id}/governances](#list-organization-governance-in-use) | 사용 중인 조직 거버넌스 목록 조회 |
+| POST |[/v1/organizations/{org-id}/project-role-groups](#create-a-common-role-group-for-projects-in-the-organization) | 조직의 프로젝트 공통 역할 그룹 생성 |
+| DELETE |[/v1/organizations/{org-id}/project-role-groups](#delete-a-project-common-role-group-in-the-organization) | 조직의 프로젝트 공통 역할 그룹 삭제 |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/infos](#modify-your-organizations-project-common-role-group-information) | 조직의 프로젝트 공통 역할 그룹 정보 수정 |
+| PUT |[/v1/organizations/{org-id}/project-role-groups/{role-group-id}/roles](#modify-your-organizations-project-common-roles-group-roles) | 조직의 프로젝트 공통 역할 그룹 역할 수정 |
+| POST |[/v1/projects/{project-id}/project-role-groups](#create-a-project-role-group) | 프로젝트 역할 그룹 생성 |
+| DELETE |[/v1/projects/{project-id}/project-role-groups](#delete-a-project-role-group) | 프로젝트 역할 그룹 삭제 |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#edit-project-role-group-information) | 프로젝트 역할 그룹 정보 수정 |
+| PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#modify-project-role-group-roles) | 프로젝트 역할 그룹 역할 수정 |
+| GET |[/v1/organizations/{org-id}/org-role-groups](#view-all-organization-role-groups) | 조직 역할 그룹 전체 조회 |
+| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#view-a-single-organization-role-group) | 조직 역할 그룹 단건 조회 |
+| POST |[/v1/organizations/{org-id}/org-role-groups](#create-organization-role-group) | 조직 역할 그룹 생성 |
+| DELETE |[/v1/organizations/{org-id}/org-role-groups](#delete-organization-role-group) | 조직 역할 그룹 삭제 |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#modify-organization-role-group-information) | 조직 역할 그룹 정보 수정 |
+| PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#modify-an-organization-role-groups-role) | 조직 역할 그룹 역할 수정 |
+| PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#modify-organization-member-roles) | 조직 멤버 역할 수정 |
+| PUT |[/v1/projects/{project-id}/members/{member-uuid}](#modify-project-member-roles) | 프로젝트 멤버 역할 수정 |
+| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#view-organization-iam-members) | 조직 IAM 계정 단건 조회 |
+| GET |[/v1/iam/organizations/{org-id}/members](#list-organization-iam-members) | 조직 IAM 계정 목록 조회 |
+| POST |[/v1/iam/organizations/{org-id}/members](#add-an-organization-iam-member) | 조직 IAM 계정 추가 |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#send-an-iam-member-password-change-email) | IAM 계정 비밀번호 변경 이메일 전송 |
+| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#modify-organization-iam-member-information) | 조직 IAM 계정 정보 수정 |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#change-an-organization-iam-member-password) | 조직 IAM 계정 비밀번호 변경 |
+| GET |[/v1/iam/organizations/{org-id}/settings/session](#view-organization-iam-sign-in-session-settings-information) | 조직 IAM 계정 로그인 세션 설정 정보를 조회 |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#view-settings-for-organizational-iam-sign-in-second-factor-authentication) | 조직 IAM 계정 로그인 2차 인증에 대한 설정을 조회 |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#view-organization-iam-login-failure-security-settings) | 조직 IAM 계정 로그인 실패 보안 설정을 조회 |
+| GET |[/v1/iam/organizations/{org-id}/settings/password-rule](#get-your-organizations-iam-account-password-policy) | 조직 IAM 계정 비밀번호 정책 조회 |
+| GET |[/v1/organizations/{org-id}/products/ip-acl](#listorganization-ip-acls) | 조직 IP ACL 목록 조회 |
+| POST |[/v1/billing/contracts/basic/products/prices/search](#get-the-price-of-a-service-on-a-pay-as-you-go-subscription) | 종량제에 등록된 서비스 가격 조회 |
+| GET |[/v1/billing/contracts/basic/products](#list-services-enrolled-in-a-pay-as-you-go-subscription) | 종량제에 등록된 서비스 목록 조회 |
+| GET | [/v1/authentications/projects/{project-id}/project-appkeys](#get-project-integrated-appkey) | 프로젝트 통합 Appkey 조회 |
+| GET |[/v1/authentications/user-access-keys](#listuser-access-key-ids) | User Access Key ID 목록 조회 |
+| POST | [/v1/authentications/projects/{project-id}/project-appkeys](#register-a-integrated-project-appkey) | 프로젝트 통합 Appkey 등록 |
+| POST |[/v1/authentications/user-access-keys](#register-a-user-access-key-id) | User Access Key ID 등록 |
+| DELETE | [/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#delete-a-project-integrated-appkey) | 프로젝트 통합 Appkey 삭제 |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#reissue-the-user-access-key-id-secret-key) | User Access Key ID 비밀 키 재발급 |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#modify-user-access-key-id-status) | User Access Key ID 상태 수정 |
+| DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#delete-a-user-access-key-id) | User Access Key ID 삭제 |
+| GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#get-a-list-of-tokens) | 토큰 목록 조회 |
+| DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#expire-multiple-tokens) | 토큰 다건 만료 |
+| POST |[/v1/iam/projects/{project-id}/members](#create-a-project-iam-account) | 프로젝트 IAM 계정 생성 |
+| DELETE |[/v1/iam/projects/{project-id}/members](#delete-multiple-project-iam-accounts) | 프로젝트 IAM 계정 다건 삭제 |
+| GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | 프로젝트 IAM 계정 단건 조회 |
+| GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | 프로젝트 IAM 계정 목록 조회 |
+| PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | 프로젝트 IAM 계정 역할 수정 |
 | GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#조직-하위-멤버의-모든-인증정보-목록-조회) | 조직 하위 멤버 인증 정보 목록 조회 |
-| GET | [/v1/organizations](#자신의-조직-목록-조회) | 자신의 조직 목록 조회 |
-| POST | [/v1/organizations](#자신의-조직-추가) | 자신의 조직 추가 |
-| DELETE | [/v1/organizations/{org-id}](#조직-단건-삭제) | 조직 단건 삭제 |
-| GET | [/v1/products](#서비스-정보-목록-조회) | 서비스 정보 목록 조회 |
-| GET | [/v1/messages/role](#역할-설명-다국어-조회) | 역할 설명 다국어 조회 |
+| GET | [/v1/organizations](#view-your-own-organization-list) | 자신의 조직 목록 조회 |
+| POST | [/v1/organizations](#add-your-own-organization) | 자신의 조직 추가 |
+| DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | 조직 단건 삭제 |
+| GET | [/v1/products](#retrieve-service-information-list) | 서비스 정보 목록 조회 |
+| GET | [/v1/messages/role](#view-role-descriptions-by-multiple-language) | 역할 설명 다국어 조회 |
 
 
 
@@ -223,7 +223,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입           | 필수 | 설명 |   
 |------------ |--------------| ------- | ------------ |
-|   header | [공통 응답](#응답) | Yes |
+|   header | [공통 응답](#common-response) | Yes |
 
 
 <a id="add-a-project"></a>
@@ -281,7 +281,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes  |
+|   header | [공통 응답](#common-response)| Yes  |
 |   regDateTime | Date| Yes   | 프로젝트 생성 일시 | 
 |   description | String| No   | 프로젝트 설명 | 
 |   ownerId | String| Yes   | 프로젝트 소유자 멤버 ID | 
@@ -333,7 +333,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 
 
 
@@ -382,7 +382,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 
 
 
@@ -433,7 +433,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   childProducts | List&lt;ChildProduct>| No   | 해당 서비스의 하위 서비스 정보로, 하위 서비스가 없으면 포함하지 않음.<br>하위 서비스를 먼저 비활성화하고 해당 서비스를 비활성화해야 함.|
 
 ##### ChildProduct
@@ -493,7 +493,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   appKey | String| Yes | 해당 프로젝트에서 이용 중인 서비스의 앱키 정보|
 |   parentProduct | ParentProduct| No | 상위 서비스 정보가 있으면 해당 정보를 표시하며, 상위 서비스가 없으면 포함하지 않음 |
 |   secretKey | String| No| 해당 프로젝트에서 이용 중인 서비스에 대한 비밀 키 정보<br> 비밀 키를 이용하는 서비스에서만 제공 |
@@ -567,7 +567,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   roles | List&lt;RoleProtocol>| Yes  | 역할 목록 |
 |   totalCount | Integer| Yes  | 총 개수 |
 
@@ -636,7 +636,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   roles | List&lt;[RoleProtocol](#roleprotocol)>| Yes  | 역할 목록 |
 |   totalCount | Integer| Yes  | 총 개수 |
 
@@ -687,7 +687,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   domainList | List&lt;OrgDomainProtocol>| Yes  |
 
 
@@ -774,7 +774,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   orgMember | OrgMemberRoleBundleProtocol| No  | 추가된 멤버 정보, 오류 시 포함되지 않음 |
 
 ##### OrgMemberRoleBundleProtocol
@@ -901,7 +901,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   orgMembers | List&lt;OrgMemberWithInviteMemberrotocol>| Yes | 조직 멤버 목록 |
 |   paging | PagingResponse| Yes | 페이지 정보 |
 
@@ -994,7 +994,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes  |
+|   header | [공통 응답](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List&lt;RoleGroupProtocol>| Yes | 프로젝트에서 사용 가능한 역할 그룹 목록  |
 
@@ -1062,7 +1062,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   productUiList | List&lt;ProductUiHierarchyProtocol>| Yes  | 홈페이지 카테고리 서비스 UI 목록 |
 
 ##### ProductUiHierarchyProtocol
@@ -1135,7 +1135,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   hasUpdateSecretKeyPermission | Boolean| Yes | 비밀 키 재발급 가능 권한  |
 |   product | ProjectProductRelationAndProductProtocol| Yes  | 지정한 서비스 ID에 대해서 프로젝트에서 사용 중인 서비스 정보를 반환, 오류 시 포함하지 않음 |
 
@@ -1228,7 +1228,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   projectMember | ProjectMemberRoleBundleProtocol| Yes  | 추가된 멤버 정보, 오류 시 포함되지 않음 |
 
 
@@ -1318,7 +1318,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List&lt;ProjectMemberProtocol>| Yes | 프로젝트 멤버  |
 
@@ -1404,7 +1404,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   roleGroup | RoleGroupBundleProtocol| Yes | 연관 역할을 포함한 역할 그룹  |
 
 ##### RoleGroupBundleProtocol
@@ -1484,7 +1484,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | 연관 역할을 포함한 역할 그룹  |
 
 
@@ -1545,7 +1545,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes  |
+|   header | [공통 응답](#common-response)| Yes  |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)>| Yes | 프로젝트에서 사용 가능한 역할 그룹 목록  |
 
@@ -1607,7 +1607,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse) | Yes |
 |   projectList | List&lt;OrgProjectMemberRoleProtocol>| Yes |
 
@@ -1671,7 +1671,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   usingGovernances | List&lt;GovernanceProtocol>| No | 사용 중인 거버넌스 목록  |
 
 
@@ -1741,7 +1741,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 
 <a id="delete-a-project-common-role-group-in-the-organization"></a>
@@ -1790,7 +1790,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-role-group-information"></a>
 ### 조직의 프로젝트 공통 역할 그룹 정보 수정 { #modify-your-organizations-project-common-role-group-information }
@@ -1841,7 +1841,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="modify-your-organizations-project-common-roles-group-roles"></a>
 ### 조직의 프로젝트 공통 역할 그룹 역할 수정 { #modify-your-organizations-project-common-roles-group-roles }
@@ -1891,7 +1891,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="create-a-project-role-group"></a>
 ### 프로젝트 역할 그룹 생성 { #create-a-project-role-group }
@@ -1935,7 +1935,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="delete-a-project-role-group"></a>
 ### 프로젝트 역할 그룹 삭제 { #delete-a-project-role-group }
@@ -1979,7 +1979,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="edit-project-role-group-information"></a>
 ### 프로젝트 역할 그룹 정보 수정 { #edit-project-role-group-information }
@@ -2022,7 +2022,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 
 <a id="modify-project-role-group-roles"></a>
@@ -2073,7 +2073,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 
 <a id="view-all-organization-role-groups"></a>
@@ -2130,7 +2130,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | --------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse) | Yes | |
 | roleGroups | List&lt;[RoleGroupProtocol](#rolegroupprotocol)> | Yes | 조직에서 사용 가능한 역할 그룹 목록 |
 
@@ -2202,7 +2202,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | --------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | roleGroup | [RoleGroupBundleProtocol](#rolegroupbundleprotocol) | Yes | 연관 역할을 포함한 역할 그룹 |
 
 <a id="create-organization-role-group"></a>
@@ -2242,7 +2242,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 
 <a id="delete-organization-role-group"></a>
 ### 조직 역할 그룹 삭제 { #delete-organization-role-group }
@@ -2281,7 +2281,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 
 <a id="modify-organization-role-group-information"></a>
 ### 조직 역할 그룹 정보 수정 { #modify-organization-role-group-information }
@@ -2321,7 +2321,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 
 
 <a id="modify-an-organization-role-groups-role"></a>
@@ -2368,7 +2368,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 | ------------ | ------------- | ----------- | ------------ |
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 
 
 <a id="modify-organization-member-roles"></a>
@@ -2423,7 +2423,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="modify-project-member-roles"></a>
 ### 프로젝트 멤버 역할 수정 { #modify-project-member-roles }
@@ -2465,7 +2465,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="view-organization-iam-members"></a>
 ### 조직 IAM 계정 단건 조회 { #view-organization-iam-members }
@@ -2558,7 +2558,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   orgMember | OrgIamMemberRoleBundleProtocol| No  |
 
 ##### OrgIamMemberRoleBundleProtocol
@@ -2691,7 +2691,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   orgMembers | List&lt;IamOrgMemberProtocol>| No | 조직 IAM 계정 목록  |
 |   paging | [PagingResponse](#pagingresponse)| No  |
 
@@ -2804,7 +2804,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   uuid | String| No | IAM 계정 UUID  |
 
 
@@ -2859,7 +2859,7 @@ IAM 계정의 비밀번호를 변경할 수 있는 이메일을 전송하는 API
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="modify-organization-iam-member-information"></a>
 ### 조직 IAM 계정 정보 수정 { #modify-organization-iam-member-information }
@@ -2931,7 +2931,7 @@ IAM 계정의 비밀번호를 변경할 수 있는 이메일을 전송하는 API
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="change-an-organization-iam-member-password"></a>
 ### 조직 IAM 계정 비밀번호 변경 { #change-an-organization-iam-member-password }
@@ -2979,7 +2979,7 @@ IAM 계정의 비밀번호를 변경할 수 있는 이메일을 전송하는 API
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="listorganization-ip-acls"></a>
 ### 조직 IP ACL 목록 조회 { #listorganization-ip-acls }
@@ -3022,7 +3022,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   orgIpAcl | List&lt;OrgIpAclProtocol>| Yes  | 설정 결과, 빈 목록이면 설정이 안된 상태 |
 
 ##### OrgIpAclProtocol
@@ -3079,7 +3079,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [공통 응답](#응답)| Yes   |
+| header | [공통 응답](#common-response)| Yes   |
 | result | Content | Yes | 설정 내용 |
 
 ##### Content
@@ -3153,7 +3153,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   result | Result| No |  응답 내용<br>설정한 적이 없으면 null이 반환됨 |
 
 ##### Result
@@ -3232,7 +3232,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [공통 응답](#응답)| Yes   |
+| header | [공통 응답](#common-response)| Yes   |
 | result | Result | No | 로그인 실패 보안을 설정한 경우에만 반환되며, 설정하지 않으면 null이 반환됨 |
 
 ##### Result
@@ -3313,7 +3313,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------------- | ------------ |
-| header | [공통 응답](#응답)| Yes   |
+| header | [공통 응답](#common-response)| Yes   |
 | result | Content | Yes | 설정 내용 |
 
 ##### Content
@@ -3435,7 +3435,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   paging | PagingResponse| Yes | 정렬 기준이 없는 페이징 결과 반환  |
 |   prices | List&lt;ContractProductPriceProtocol>| Yes | 카운터의 단가 정보를 배열로 반환<br>오류 시 포함되지 않음  |
 
@@ -3535,7 +3535,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   products | List&lt;ProductMetadata>| Yes | 서비스 메타 정보 목록  |
 
@@ -3614,7 +3614,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   authenticationList | List&lt;ProjectAppKeyResponse>| No | 프로젝트 통합 Appkey 목록 |
 
 ##### ProjectAppKeyResponse
@@ -3676,7 +3676,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   authentications | List&lt;UserAccessKeyResponse>| No | 인증 정보 목록  |
 
 ##### UserAccessKeyResponse
@@ -3746,7 +3746,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3808,7 +3808,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3860,7 +3860,7 @@ IP ACL 설정을 조회하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 
 <a id="reissue-the-user-access-key-id-secret-key"></a>
@@ -3911,7 +3911,7 @@ User Access Key ID의 비밀 키를 재발급하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | --------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   authentication | ResponseProtocol| No  |
 
 ##### ResponseProtocol
@@ -3967,7 +3967,7 @@ OPAQUE 토큰용 User Access Key ID를 중지시키면 OPAQUE 토큰도 같이 �
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 <a id="delete-a-user-access-key-id"></a>
 ### User Access Key ID 삭제 { #delete-a-user-access-key-id }
@@ -4006,7 +4006,7 @@ User Access Key ID를 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 
 
 <a id="get-a-list-of-tokens"></a>
@@ -4065,7 +4065,7 @@ User Access Key ID로 발급한 OPAQUE 토큰 목록을 조회하는 API입니�
 
 | 이름 | 타입           | 필수  | 설명                 |   
 |------------ |--------------|-----|--------------------|
-|   header | [공통 응답](#응답) | Yes |
+|   header | [공통 응답](#common-response) | Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   accessToken | String       | Yes | 마스킹 처리된 토큰         |
 |   expireDatetime | Date         | No  | 토큰 만료일             |
@@ -4117,7 +4117,7 @@ JWT 토큰을 발급한 User Access Key ID로 요청해도 JWT 토큰은 만료�
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 
 
 <a id="create-a-project-iam-account"></a>
@@ -4194,7 +4194,7 @@ IAM 계정을 프로젝트 멤버로 추가하는 API입니다.
 
 | 이름 | 타입           | 필수 | 설명 |   
 |------------ |--------------| ------- | ------------ |
-|   header | [공통 응답](#응답) | Yes |
+|   header | [공통 응답](#common-response) | Yes |
 
 
 <a id="delete-multiple-project-iam-accounts"></a>
@@ -4245,7 +4245,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 
 
 <a id="view-a-project-iam-account"></a>
@@ -4316,7 +4316,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   projectMember | ProjectIamMemberRoleBundleProtocol| Yes  | 추가된 멤버 정보, 오류 시 포함되지 않음 |
 
 
@@ -4398,7 +4398,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   projectMembers | List&lt;IamProjectMemberProtocol>| Yes | 프로젝트 멤버 목록  |
 
@@ -4461,7 +4461,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ----------- | ------------ |
-|   header | [공통 응답](#응답)| Yes   |
+|   header | [공통 응답](#common-response)| Yes   |
 
 
 <a id="view-all-credentials-of-members-under-organizations"></a>
@@ -4528,7 +4528,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |   
 |------------ | ------------- | ------- | ------------ |
-|   header | [공통 응답](#응답)| Yes |
+|   header | [공통 응답](#common-response)| Yes |
 |   paging | [PagingResponse](#pagingresponse)| Yes  |
 |   authenticationList | List&lt;UserAccessKeyResponseV7>| Yes  | 멤버별 인증 키 정보 |
 
@@ -4618,7 +4618,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | orgList | List&lt;OrgMemberRelationProtocol> | Yes | 조직 목록 정보 |
 | paging | [PagingResponse](#pagingresponse) | Yes | 페이징 정보 |
 
@@ -4720,7 +4720,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | orgId | String | Yes | 조직 ID |
 | orgName | String | Yes | 조직 이름 |
 | owner | [Owner](#owner) | Yes | 조직 Owner 정보 |
@@ -4771,7 +4771,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 
 
 <a id="retrieve-service-information-list"></a>
@@ -4829,7 +4829,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | paging | [PagingResponse](#pagingresponse)| Yes | |
 | products | List&lt;Product> | Yes | 서비스 정보 목록 |
 
@@ -4903,7 +4903,7 @@ IAM 계정을 해당 프로젝트에서 삭제하는 API입니다.
 
 | 이름 | 타입 | 필수 | 설명 |
 |---|---|---|---|
-| header | [공통 응답](#응답) | Yes | |
+| header | [공통 응답](#common-response) | Yes | |
 | messages | List&lt;MessageProtocol> | Yes | 메시지 목록 |
 | paging | [PagingResponse](#pagingresponse)| Yes | |
 


### PR DESCRIPTION
`public-api/framework-api.md` 3개 언어 파일에서 in-file `[text](#slug)` 링크 fragment 을 canonical anchor id 로 재작성한 별도 PR. #371 의 canonicalize_anchors 커밋 (`45227550`) 이후 fragment 이 broken 상태가 된 것을 semantic 매칭으로 fix.

## 배경

#371 위에서 진행된 canonicalize_anchors 커밋이 h2..h4 heading anchor id 를 English-derived ASCII slug (`create-a-project-member`, `list-organization-roles` 등) 로 통일했습니다. 그런데 문서 본문에는 옛 Korean/Japanese-slug 을 참조하는 `[text](#slug)` 링크가 각 파일에 ~180개씩 남아 있어서 전부 broken 상태였습니다:

```
| POST |[/v1/projects/{project-id}/members](#프로젝트-멤버-생성) | 프로젝트 멤버 생성 |
                                          ^^^^^^^^^^^^^^^^ ← fragment 은 옛 Korean-slug
                                                             (canonical id 는 이제 `create-a-project-member`)
```

## 적용한 알고리즘

`.claude/rules` 의 in-file / in-repo link fragment rewriter 프롬프트 SYSTEM rules 그대로 결정론적 스크립트로 구현:

1. **정의된 anchor id 집합 수집** — `<a id>`, `<a name>`, `<tag id>`, heading 뒤 `{ #id }` 로 정의된 X 의 case-insensitive 집합 (파일 내 fenced code 무시).
2. **Slug → canonical id 맵 구축** — ko/en/ja 3개 파일이 position-aligned + same canonical id 라는 점을 활용해 unified lookup. 각 heading text 를 두 가지 normalize:
   - (a) `dash → space, collapse whitespace, casefold`
   - (b) 같은 처리 후 whitespace 전부 strip (일본어 no-space 슬러그 대응: fragment `プロジェクト-メンバー-作成` ↔ 헤딩 `プロジェクトメンバー作成`)
3. **각 fragment 매칭**:
   - external URL 이면 skip
   - 이미 file 내 anchor id 집합에 있으면 leave-alone (resolves already)
   - 두 normalize 중 하나로 slug_map hit 면 → canonical id 로 rewrite
   - 아니면 leave-alone (prompt 원칙: 확신 없으면 두고 간다)
4. **Byte-preserve** — heading, `<a id>`, body prose, code, 표, EOL 전부 그대로. 오직 `#` 과 `)` 사이 fragment 문자열만 교체.

## 결과

| 파일 | rewritten | left alone | 총 링크 |
|---|---:|---:|---:|
| `ko/public-api/framework-api.md` | 141 | 41 | 183 |
| `en/public-api/framework-api.md` | 129 | 53 | 183 |
| `ja/public-api/framework-api.md` | 133 | 46 | 180 |
| **TOTAL** | **403** | **140** | 546 |

## 샘플 재작성

Ko 파일 (라인 76 근처):

```diff
-| POST |[/v1/projects/{project-id}/members](#프로젝트-멤버-생성) | 프로젝트 멤버 생성 |
-| POST |[/v1/organizations/{org-id}/projects](#프로젝트-추가) | 프로젝트 추가 |
-| GET |[/v1/organizations/{org-id}/roles](#조직-역할-목록-조회) | 조직 역할 목록 조회 |
+| POST |[/v1/projects/{project-id}/members](#create-a-project-member) | 프로젝트 멤버 생성 |
+| POST |[/v1/organizations/{org-id}/projects](#add-a-project) | 프로젝트 추가 |
+| GET |[/v1/organizations/{org-id}/roles](#list-organization-roles) | 조직 역할 목록 조회 |
```

Ja 파일 (라인 72 근처):

```diff
-| POST |[/v1/projects/{project-id}/members](#プロジェクト-メンバー-作成) | プロジェクトメンバー作成 |
+| POST |[/v1/projects/{project-id}/members](#create-a-project-member) | プロジェクトメンバー作成 |
```

Link text 는 URL 경로 그대로, heading 도 그대로, fragment 만 canonical id 로 정렬.

## Leave-alone 140 건의 성격

세 가지 카테고리로 나뉩니다:

### (1) Protocol / Type reference (~90 건)

```
[RoleProtocol](#roleprotocol)
[PagingResponse](#pagingresponse)
[RoleBundleProtocol](#rolebundleprotocol)
```

이들은 h5 (또는 h6) 로 배치된 protocol/type 정의 heading 이라 `MAX_ID_LEVEL=4` 규칙에 따라 canonical anchor id 를 안 받습니다. mkdocs-material 이 render 시점에 auto-slug (`#roleprotocol` = 헤딩 `RoleProtocol` 을 소문자화) 를 생성하므로 fragment 이 이미 auto-slug 와 일치 → 실제 렌더 링크는 정상 작동. Tool 관점에선 아무것도 안 함이 맞음.

### (2) Semantic drift — heading 텍스트 rename (~40 건, en 파일 위주)

```
[/v1/iam/organizations/.../members/...](#조직-IAM-멤버-단건-조회)
                                        ^^^^^^^^^ ← "IAM 멤버" 가 지금은 "IAM 계정"
```

과거 heading `조직 IAM 멤버 단건 조회` 가 지금은 `조직 IAM 계정 단건 조회` 로 rename 됨. Fragment 은 옛 이름 참조. 이건 semantic 판단이 필요, 자동 매칭으로 확정하지 않고 남겨둠. PR 리뷰 시 개별 판정 대상.

### (3) 조사 차이 (~10 건, ja 파일 위주)

일본어 조사 하나만 다른 경우 (`の` ↔ `に対する` 등). 의미상 같은 heading 가리키는 게 확실하지만 정규화 규칙으로 잡기 어려움.

## Base 선택

이 PR 의 base 는 `pre-align/fix-headings-20260730-012253` (즉 #371 head) 로 지정. 이유:

- 이 PR 의 변경사항은 #371 의 canonicalize_anchors 결과 (English-derived slug) 에 의존
- #371 이 alpha 로 merge 되기 전에 그 위에서 이 링크 fix 를 얹으면 clean 하게 함께 반영됨