### PR TITLE
fix(framework-api): 20 semantic-drift broken anchors (heading rename 이후 링크 미갱신)

### DIFF
--- a/en/public-api/framework-api.md
+++ b/en/public-api/framework-api.md
@@ -110,24 +110,24 @@ When the Public API returns, the header part below is included in the response b
 | PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/roles](#modify-an-organization-role-groups-role) | Modify an organization role group's role |
 | PUT |[/v1/organizations/{org-id}/members/{member-uuid}](#modify-organization-member-roles) | Modify organization member roles |
 | PUT |[/v1/projects/{project-id}/members/{member-uuid}](#modify-project-member-roles) | Modify project member roles |
-| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#조직-IAM-멤버-단건-조회) | View organization IAM members |
-| GET |[/v1/iam/organizations/{org-id}/members](#조직-IAM-멤버-목록-조회) | List organization IAM members |
-| POST |[/v1/iam/organizations/{org-id}/members](#조직-IAM-멤버-추가) | Add an organization IAM member |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#IAM-멤버-비밀번호-변경-이메일-전송) | Send an IAM member password change email |
-| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#조직-IAM-멤버-정보-수정) | Modify organization IAM member information |
-| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#조직-IAM-멤버-비밀번호-변경) | Change an organization IAM member password |
-| GET |[/v1/iam/organizations/{org-id}/settings/session](#조직-IAM-로그인-세션-설정-정보를-조회) | View organization IAM sign-in session settings information |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#조직-IAM-로그인-2차-인증에-대한-설정을-조회) | View settings for organizational IAM sign-in second factor authentication |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#조직-IAM-로그인-실패-보안-설정을-조회) | View Organization IAM Login Failure Security Settings |
+| GET |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#view-organization-iam-members) | View organization IAM members |
+| GET |[/v1/iam/organizations/{org-id}/members](#list-organization-iam-members) | List organization IAM members |
+| POST |[/v1/iam/organizations/{org-id}/members](#add-an-organization-iam-member) | Add an organization IAM member |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/send-password-setup-mail](#send-an-iam-member-password-change-email) | Send an IAM member password change email |
+| PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#modify-organization-iam-member-information) | Modify organization IAM member information |
+| POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#change-an-organization-iam-member-password) | Change an organization IAM member password |
+| GET |[/v1/iam/organizations/{org-id}/settings/session](#view-organization-iam-sign-in-session-settings-information) | View organization IAM sign-in session settings information |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#view-settings-for-organizational-iam-sign-in-second-factor-authentication) | View settings for organizational IAM sign-in second factor authentication |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#view-organization-iam-login-failure-security-settings) | View Organization IAM Login Failure Security Settings |
 | GET |[/v1/iam/organizations/{org-id}/settings/password-rule](#get-your-organizations-iam-account-password-policy) | Get your organization's IAM account password policy |
 | GET |[/v1/organizations/{org-id}/products/ip-acl](#listorganization-ip-acls) | Listorganization IP ACLs |
 | POST |[/v1/billing/contracts/basic/products/prices/search](#get-the-price-of-a-service-on-a-pay-as-you-go-subscription) | Get the price of a service on a pay-as-you-go subscription |
 | GET |[/v1/billing/contracts/basic/products](#list-services-enrolled-in-a-pay-as-you-go-subscription) | List services enrolled in a pay-as-you-go subscription |
-| GET |[/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-AppKey-조회) | Get Project AppKey |
+| GET |[/v1/authentications/projects/{project-id}/project-appkeys](#get-project-integrated-appkey) | Get Project AppKey |
 | GET |[/v1/authentications/user-access-keys](#listuser-access-key-ids) | ListUser Access Key IDs |
-| POST |[/v1/authentications/projects/{project-id}/project-appkeys](#프로젝트-AppKey-등록) | Register a project AppKey |
+| POST |[/v1/authentications/projects/{project-id}/project-appkeys](#register-a-integrated-project-appkey) | Register a project AppKey |
 | POST |[/v1/authentications/user-access-keys](#register-a-user-access-key-id) | Register a User Access Key ID |
-| DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#프로젝트-AppKey-삭제) | Delete a project AppKey |
+| DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#delete-a-project-integrated-appkey) | Delete a project AppKey |
 | PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#reissue-the-user-access-key-id-secret-key) | Reissue the User Access Key ID secret key |
 | PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#modify-user-access-key-id-status) | Modify User Access Key ID status |
 | DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#delete-a-user-access-key-id) | Delete a User Access Key ID |
@@ -138,7 +138,7 @@ When the Public API returns, the header part below is included in the response b
 | GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | View a project IAM account |
 | GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | View project IAM accounts |
 | PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | Modify project IAM account roles |
-| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#조직-하위-멤버의-모든-인증정보-리스트-조회) | View all credentials of members under organizations |
+| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#view-all-credentials-of-members-under-organizations) | View all credentials of members under organizations |
 | GET | [/v1/organizations](#view-your-own-organization-list) | View your own organization list |
 | POST | [/v1/organizations](#add-your-own-organization) | Add your own organization |
 | DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | Delete a single organization |

--- a/ja/public-api/framework-api.md
+++ b/ja/public-api/framework-api.md
@@ -98,8 +98,8 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | DELETE |[/v1/projects/{project-id}/project-role-groups](#delete-a-project-role-group) | プロジェクトロールグループ削除 |
 | PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/infos](#edit-project-role-group-information) | プロジェクトロールグループ情報修正 |
 | PUT |[/v1/projects/{project-id}/project-role-groups/{role-group-id}/roles](#modify-project-role-group-roles) | プロジェクトロールグループロール修正 |
-| GET |[/v1/organizations/{org-id}/org-role-groups](#組織-ロール-グループ-全体-照会) | 組織ロールグループ全体照会 |
-| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#組織-ロール-グループ-単件-照会) | 組織ロールグループ単件照会 |
+| GET |[/v1/organizations/{org-id}/org-role-groups](#view-all-organization-role-groups) | 組織ロールグループ全体照会 |
+| GET |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}](#view-a-single-organization-role-group) | 組織ロールグループ単件照会 |
 | POST |[/v1/organizations/{org-id}/org-role-groups](#create-organization-role-group) | 組織ロールグループ作成 |
 | DELETE |[/v1/organizations/{org-id}/org-role-groups](#delete-organization-role-group) | 組織ロールグループ削除 |
 | PUT |[/v1/organizations/{org-id}/org-role-groups/{role-group-id}/infos](#modify-organization-role-group-information) | 組織ロールグループ情報修正 |
@@ -113,10 +113,10 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | PUT |[/v1/iam/organizations/{org-id}/members/{member-uuid}](#modify-organization-iam-member-information) | 組織IAMメンバー情報修正 |
 | POST |[/v1/iam/organizations/{org-id}/members/{member-id}/set-password](#change-an-organization-iam-member-password) | 組織IAMメンバーパスワード変更 |
 | GET |[/v1/iam/organizations/{org-id}/settings/session](#view-organization-iam-sign-in-session-settings-information) | 組織IAMログインセッション設定情報を照会 |
-| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#組織-IAM-ログイン-2次-認証-の-設定を-照会) | 組織IAMログイン2段階認証の設定を照会 |
+| GET |[/v1/iam/organizations/{org-id}/settings/security-mfa](#view-settings-for-organizational-iam-sign-in-second-factor-authentication) | 組織IAMログイン2段階認証の設定を照会 |
 | GET |[/v1/iam/organizations/{org-id}/settings/security-login-fail](#view-organization-iam-login-failure-security-settings) | 組織IAMログイン失敗セキュリティ設定を照会 |
 | GET |[/v1/organizations/{org-id}/products/ip-acl](#listorganization-ip-acls) | 組織IP ACLリスト照会 |
-| POST |[/v1/billing/contracts/basic/products/prices/search](#従量制に-登録された-サービス-価格-照会) | 従量制に登録されたサービス価格照会 |
+| POST |[/v1/billing/contracts/basic/products/prices/search](#get-the-price-of-a-service-on-a-pay-as-you-go-subscription) | 従量制に登録されたサービス価格照会 |
 | GET |[/v1/billing/contracts/basic/products](#list-services-enrolled-in-a-pay-as-you-go-subscription) | 従量制に登録されたサービスリスト照会 |
 | GET |[/v1/authentications/projects/{project-id}/project-appkeys](#get-project-integrated-appkey) | プロジェクト統合-Appkey照会 |
 | GET |[/v1/authentications/user-access-keys](#listuser-access-key-ids) | User Access Key IDリスト照会 |
@@ -124,7 +124,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | POST |[/v1/authentications/user-access-keys](#register-a-user-access-key-id) | User Access Key ID登録 |
 | DELETE |[/v1/authentications/projects/{project-id}/project-appkeys/{app-key}](#delete-a-project-integrated-appkey) | プロジェクト統合-Appkey削除 |
 | PUT |[/v1/authentications/user-access-keys/{user-access-key-id}/secretkey-reissue](#reissue-the-user-access-key-id-secret-key) | User Access Key ID秘密鍵の再発行 |
-| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#User-Access-Key-ID-状態-修正) | User Access Key ID状態修正 |
+| PUT |[/v1/authentications/user-access-keys/{user-access-key-id}](#modify-user-access-key-id-status) | User Access Key ID状態修正 |
 | DELETE |[/v1/authentications/user-access-keys/{user-access-key-id}](#delete-a-user-access-key-id) | User Access Key ID削除 |
 | GET    | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#get-a-list-of-tokens)                               | トークンリスト照会                 |
 | DELETE | [/v1/authentications/user-access-keys/{user-access-key-id}/tokens](#expire-multiple-tokens)                               | トークン複数期限切れ                  |
@@ -133,7 +133,7 @@ Public APIの返却時、下記のヘッダ部分がレスポンス本文に含�
 | GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | プロジェクトIAMアカウント単件照会 |
 | GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | プロジェクトIAMアカウントリスト照会 |
 | PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | プロジェクトIAMアカウントロール修正 |
-| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#組織-下位-メンバーの-全ての-認証情報-リスト-照会) | 組織下位メンバー認証情報リスト照会 |
+| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#view-all-credentials-of-members-under-organizations) | 組織下位メンバー認証情報リスト照会 |
 | GET | [/v1/organizations](#view-your-own-organization-list) | 自分の組織一覧の照会 |
 | POST | [/v1/organizations](#add-your-own-organization) | 自分の組織の追加 |
 | DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | 組織の個別削除 |

--- a/ko/public-api/framework-api.md
+++ b/ko/public-api/framework-api.md
@@ -138,7 +138,7 @@ Public API 반환 시 아래 헤더 부분이 응답 본문에 포함됩니다.
 | GET |[/v1/iam/projects/{project-id}/members/{member-uuid}](#view-a-project-member) | 프로젝트 IAM 계정 단건 조회 |
 | GET |[/v1/iam/projects/{project-id}/members](#view-project-iam-accounts) | 프로젝트 IAM 계정 목록 조회 |
 | PUT |[/v1/iam/projects/{project-id}/members/{member-uuid}](#modify-project-iam-account-roles) | 프로젝트 IAM 계정 역할 수정 |
-| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#조직-하위-멤버의-모든-인증정보-목록-조회) | 조직 하위 멤버 인증 정보 목록 조회 |
+| GET |[/v1/authentications/organizations/{org-id}/user-access-keys](#view-all-credentials-of-members-under-organizations) | 조직 하위 멤버 인증 정보 목록 조회 |
 | GET | [/v1/organizations](#view-your-own-organization-list) | 자신의 조직 목록 조회 |
 | POST | [/v1/organizations](#add-your-own-organization) | 자신의 조직 추가 |
 | DELETE | [/v1/organizations/{org-id}](#delete-a-single-organization) | 조직 단건 삭제 |


### PR DESCRIPTION
`viewer/anchor_check.check()` 로 재확인한 broken anchor 140건 중 **진짜 broken 20건을 canonical id 로 수동 교체**. 나머지 120건은 h5 type/protocol reference 로 mkdocs auto-slug 로 실제 render 시엔 정상 작동 (도구 오탐, 별개 트랙).

## 근본 원인

과거 어느 시점에 heading text 를 rename 했는데 문서 내 `[…](#옛-heading)` 링크는 함께 갱신 안 됨:

- **ko heading text 만** `IAM 멤버 → IAM 계정 (로그인)` 으로 rename 됐고 canonical anchor id 는 여전히 `iam-member` 계열 (English derived)
- **ja heading text** 는 `全体→全件`, `単件→個別`, `2次→2段階`, `サービス→商品` 등 표기 개선
- `프로젝트 AppKey → 프로젝트 통합 Appkey` 로 `통합` 삽입 (ko heading 수정)

자동 매칭 도구 [#372](https://github.com/TOAST-DOCS/TOAST-Cloud/pull/372) 는 whitespace/case-insensitive **exact match** 라 이 rename drift 를 놓쳤음. 이 PR 은 fuzzy string similarity 로 조사한 결과 (>0.75 confidence) 를 사람 리뷰 후 개별 교체.

## Fix 상세 (20건)

### ko/framework-api.md — 1건

| Line | Old fragment | New canonical id | Rename 유형 |
|---|---|---|---|
| L141 | `#조직-하위-멤버의-모든-인증정보-목록-조회` | `#view-all-credentials-of-members-under-organizations` | 조사 `-의`/`모든` 제거, `인증정보` → `인증 정보` (띄어쓰기) |

### en/framework-api.md — 13건 (전부 한글 fragment)

**IAM 멤버 → IAM 계정 rename (6건)**:

| Line | Old fragment | New canonical id |
|---|---|---|
| L113 | `#조직-IAM-멤버-단건-조회` | `#view-organization-iam-members` |
| L114 | `#조직-IAM-멤버-목록-조회` | `#list-organization-iam-members` |
| L115 | `#조직-IAM-멤버-추가` | `#add-an-organization-iam-member` |
| L116 | `#IAM-멤버-비밀번호-변경-이메일-전송` | `#send-an-iam-member-password-change-email` |
| L117 | `#조직-IAM-멤버-정보-수정` | `#modify-organization-iam-member-information` |
| L118 | `#조직-IAM-멤버-비밀번호-변경` | `#change-an-organization-iam-member-password` |

**IAM 로그인 → IAM 계정 로그인 (3건)**:

| Line | Old fragment | New canonical id |
|---|---|---|
| L119 | `#조직-IAM-로그인-세션-설정-정보를-조회` | `#view-organization-iam-sign-in-session-settings-information` |
| L120 | `#조직-IAM-로그인-2차-인증에-대한-설정을-조회` | `#view-settings-for-organizational-iam-sign-in-second-factor-authentication` |
| L121 | `#조직-IAM-로그인-실패-보안-설정을-조회` | `#view-organization-iam-login-failure-security-settings` |

**프로젝트 AppKey → 프로젝트 통합 Appkey (3건)**:

| Line | Old fragment | New canonical id |
|---|---|---|
| L126 | `#프로젝트-AppKey-조회` | `#get-project-integrated-appkey` |
| L128 | `#프로젝트-AppKey-등록` | `#register-a-integrated-project-appkey` |
| L130 | `#프로젝트-AppKey-삭제` | `#delete-a-project-integrated-appkey` |

**기타 (1건)**:

| Line | Old fragment | New canonical id |
|---|---|---|
| L141 | `#조직-하위-멤버의-모든-인증정보-리스트-조회` | `#view-all-credentials-of-members-under-organizations` |

### ja/framework-api.md — 6건

**한자 rename (4건)**:

| Line | Old fragment | New canonical id | 변경 |
|---|---|---|---|
| L101 | `#組織-ロール-グループ-全体-照会` | `#view-all-organization-role-groups` | `全体` → `全件` |
| L102 | `#組織-ロール-グループ-単件-照会` | `#view-a-single-organization-role-group` | `単件` → `個別` |
| L116 | `#組織-IAM-ログイン-2次-認証-の-設定を-照会` | `#view-settings-for-organizational-iam-sign-in-second-factor-authentication` | `2次` → `2段階` |
| L119 | `#従量制に-登録された-サービス-価格-照会` | `#get-the-price-of-a-service-on-a-pay-as-you-go-subscription` | `サービス` → `商品` |

**조사/공백 정리 (2건)**:

| Line | Old fragment | New canonical id | 변경 |
|---|---|---|---|
| L127 | `#User-Access-Key-ID-状態-修正` | `#modify-user-access-key-id-status` | `の` 삽입 |
| L136 | `#組織-下位-メンバーの-全ての-認証情報-リスト-照会` | `#view-all-credentials-of-members-under-organizations` | `の`/`全ての` 제거 |

## 검증

`viewer/anchor_check.check()` 재실행:

| 파일 | Before | After | Drop |
|---|---:|---:|---:|
| ko/framework-api.md | 41 | 40 | -1 ✅ |
| en/framework-api.md | 53 | 40 | -13 ✅ |
| ja/framework-api.md | 46 | 40 | -6 ✅ |
| **TOTAL** | **140** | **120** | **-20** ✅ |

Drop count 가 fix 개수와 정확히 일치 — over-application 없음, under-application 없음.

## 남은 120건 (이 PR 범위 밖)

전부 h5 type/protocol reference (`#pagingresponse`, `#rolebundleprotocol`, `#createrolegrouprequest` 등). mkdocs-material 이 render 시점에 auto-slug 로 처리해서 **실제로는 작동**하지만 `anchor_check` 가 explicit `<a id>` / `{ #id }` 만 스캔해서 오탐. 이 오탐은 도구쪽 fix (`viewer/anchor_check.py` 를 auto-slug 인식하도록 확장) 로 해결 대상이며, 이 PR 은 소스 문서만 다룸.

## Base 선택

Base 는 `pre-align/fix-headings-20260730-012253` (#371 head). 이유:

- 이 fix 는 #371 의 canonicalize_anchors 결과 (English-derived slug) 를 target 으로 함
- #371 이 alpha 로 merge 되기 전에 그 위에 얹혀야 clean 하게 함께 반영됨

## 관련 PR / 이슈

- [#371](https://github.com/TOAST-DOCS/TOAST-Cloud/pull/371) — canonicalize_anchors, target 정의
- [#372](https://github.com/TOAST-DOCS/TOAST-Cloud/pull/372) — 정규화 매칭 기반 자동 link fix (543건 중 403건 해결, 이번 PR 이 나머지 20건 처리)
- [cloud-translate#361](https://github.nhnent.com/TOASTCloud/cloud-translate/issues/361) — 재번역 self-verify 부재 (별개 이슈)