### PR TITLE
chore: terraform-guide gov variant 통합 (검증용, 머지 금지)

### DIFF
--- a/ko/terraform-guide.md
+++ b/ko/terraform-guide.md
@@ -142,11 +142,9 @@ provider "nhncloud" {
     * NHN Cloud 콘솔의 **Compute > Instance > 관리** 메뉴에서 **API 엔드포인트 설정** 버튼을 클릭해 신원 서비스(identity) URL을 확인합니다.
 * **region**
     * NHN Cloud 리소스를 관리할 리전 정보를 입력합니다.
-    * **KR1**: 한국(판교) 리전
-{% if "gov" not in build_flags -%}
+    * **KR1**: 한국(판교) 리전{% if "gov" not in build_flags %}
     * **KR2**: 한국(평촌) 리전
-    * **JP1**: 일본(도쿄) 리전
-{%- endif %}
+    * **JP1**: 일본(도쿄) 리전{% endif %}
 
 공급자 설정 파일이 있는 경로에서 `init` 명령을 이용해 Terraform을 초기화합니다.
 

--- a/ko/terraform-guide.md
+++ b/ko/terraform-guide.md
@@ -125,7 +125,7 @@ provider "nhncloud" {
   user_name   = "terraform-guide@nhncloud.com"
   tenant_id   = "aaa4c0a12fd84edeb68965d320d17129"
   password    = "difficultpassword"
-  auth_url    = "https://api-identity-infrastructure.nhncloudservice.com/v2.0"
+  auth_url    = "https://api-identity-infrastructure.{% if "gov" in build_flags %}gov-{% endif %}nhncloudservice.com/v2.0"
   region      = "KR1"
 }
 ```
@@ -143,8 +143,10 @@ provider "nhncloud" {
 * **region**
     * NHN Cloud 리소스를 관리할 리전 정보를 입력합니다.
     * **KR1**: 한국(판교) 리전
+{% if "gov" not in build_flags -%}
     * **KR2**: 한국(평촌) 리전
     * **JP1**: 일본(도쿄) 리전
+{%- endif %}
 
 공급자 설정 파일이 있는 경로에서 `init` 명령을 이용해 Terraform을 초기화합니다.
 


### PR DESCRIPTION
## Summary

`ko/terraform-guide.md` + `ko/terraform-guide-gov.md` 를 build_flags 로 통합.

⚠️ **머지 금지** — 검증용 실험 PR.

## 통합 방식

Public canonical 을 base 로 유지. 조건 분기는 2 곳:

1. `auth_url` 예제 코드 안 도메인 — inline: `nhncloudservice.com` → `gov-nhncloudservice.com`
2. `KR2`/`JP1` 리전 bullet — gov 에서 숨김 (inline `{% if %}` end-of-line 패턴, list continuation 유지)

파일 크기: 1469 → 1471 lines (+2 lines, +0.1%).

## 검증 결과

| build_flags | 결과 |
|---|---|
| (default → public) | **EXACT** |
| `gov` | **NORMALIZED-MATCH** — variant-source drift (canonical markup + wording) 만 남음 |

### Variant-source drift (public canonical 로 통일)

- gov 원본: `Terraform Registry` → canonical `NHN Cloud Terraform Registry` (링크 label)
- gov 원본: 각 heading 에 `{ #id }` suffix + `<a id>` block 부재 → merged 는 unconditional 로 canonical markup 유지
- 예제 로그 elapsed time · UUID 등 미세 차이 — 임의 예제이므로 public canonical 사용

## Preview 링크

| build_flags | 링크 |
|---|---|
| public | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=terraform-guide.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=terraform-guide-merge-20260806) |
| `gov` | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=terraform-guide.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=terraform-guide-merge-20260806&flags=gov) |
| 원본 `terraform-guide-gov.md` | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=terraform-guide-gov.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=alpha) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
