### PR TITLE
chore: region-guide gov variant 통합 (검증용, 머지 금지)

### DIFF
--- a/ko/region-guide.md
+++ b/ko/region-guide.md
@@ -4,20 +4,22 @@
 ## NHN Cloud > 리전 가이드 { #nhn-cloud-guide-to-nhn-cloud-regions }
 리전은 독립적이고 지리적으로 격리된 서버의 물리적 위치를 의미합니다.
 일반적으로 리전은 가용성 영역이라고 부르는 독립된 전원 및 네트워크를 갖춘 데이터 센터로 구성되며, 사용하려는 지역과 서비스에 따라 리전을 선택할 수 있습니다.
-인터넷으로 언제 어디서나 자유롭게 리전을 선택하여 NHN Cloud 서비스를 이용하세요.
+인터넷으로 언제 어디서나 자유롭게 리전을 선택하여 NHN Cloud{% if "gov" in build_flags %}(공공기관용){% endif %} 서비스를 이용하세요.
 
 <a id="nhn-cloud-regions"></a>
 ## NHN Cloud 리전 { #nhn-cloud-regions }
 
-NHN Cloud는 안정적인 글로벌 서비스 제공을 위해 4개의 리전을 운영하고 있습니다.
+NHN Cloud{% if "gov" in build_flags %}(공공기관용)는 안정적인 글로벌 서비스 제공을 위해 2개{% else %}는 안정적인 글로벌 서비스 제공을 위해 4개{% endif %}의 리전을 운영하고 있습니다.
 고가용성을 지원하기 위해서는 여러 가용성 영역 혹은 복수의 리전에 애플리케이션을 배포해야 합니다.
-NHN Cloud 유저는 서비스 지역과 목적에 따라 사용할 리전을 선택할 수 있으며, 일반적으로 서비스 대상이 주로 위치한 지역의 리전을 이용하면 짧은 응답 시간을 기대할 수 있습니다.
+NHN Cloud{% if "gov" in build_flags %}(공공기관용){% endif %} 유저는 서비스 지역과 목적에 따라 사용할 리전을 선택할 수 있으며, 일반적으로 서비스 대상이 주로 위치한 지역의 리전을 이용하면 짧은 응답 시간을 기대할 수 있습니다.
 
+{% if "gov" not in build_flags -%}
 <a id="location-of-toat-regions"></a>
 ## NHN Cloud 리전 위치 { #location-of-toat-regions }
 NHN Cloud는 글로벌한 서비스 제공을 위해 더 많은 지역으로 리전을 확대하고 있습니다.
 ![region_guide%2001.png](https://static.toastoven.net/toast/region_guide/Docs_NHNCloud_Region-Guide_KR.png)
 
+{% endif -%}
 <a id="nhn-cloud-regional-service"></a>
 ## NHN Cloud 리전 서비스 { #nhn-cloud-regional-service }
 **리전 서비스**
@@ -31,6 +33,82 @@ NHN Cloud는 글로벌한 서비스 제공을 위해 더 많은 지역으로 리
 
 **글로벌/리전별 제공 서비스**
 
+{% if "gov" in build_flags -%}
+| 분류 | 서비스명 | 글로벌/리전 서비스 | 한국(판교) 리전 | 한국(평촌) 리전 |
+| --- | ---- | :--------: | :-------: | :-------: |
+| Compute | Instance | 리전 | O | O |
+|  | GPU Instance | 리전 | O | O |
+|  | Instance Template | 리전 | O | O |
+|  | Image | 리전 | O | O |
+|  | Image Builder  | 리전 | O | O |
+|  | Auto Scale | 리전 | O | O |
+|  | Virtual Desktop | 리전 | O | O |
+| Container | NHN Kubernetes Service(NKS) | 리전 | O | O |
+|  | NHN Container Registry (NCR) | 리전 | O | O |
+|  | NHN Container Service(NCS)  | 리전 | O |  |
+| Network | VPC | 리전 | O | O |
+|  | NAT Instance | 리전 | O | O |
+|  | Floating IP | 리전 | O | O |
+|  | Security Groups | 리전 | O | O |
+|  | Network ACL | 리전 | O | O |
+|  | Network Interface | 리전 | O | O |
+|  | 일반 Load Balancer | 리전 | O | O |
+|  | 전용 Load Balancer | 리전 | O | O |
+|  | Load Balancer(DSR) | 리전 | O |  |
+|  | Transit Hub  | 리전 | O |  |
+|  | IPSec VPN | 리전 | O |  |
+|  | Internet Gateway | 리전 | O | O |
+|  | Peering Gateway | 리전 | O | O |
+|  | Colocation Gateway | 리전 | O | O |
+|  | NAT Gateway | 리전 | O |  |
+|  | Service Gateway | 리전 | O | O |
+|  | Traffic Mirroring | 리전 | O |  |
+|  | Private DNS | 리전 | O |  |
+|  | DNS Plus | 글로벌 |  |  |
+|  | Direct Connect | 리전 | O | O |
+| Storage | Block Storage | 리전 | O | O |
+|  | NAS | 리전 | O | O |
+|  | NAS(offline) | 리전 | O |  |
+|  | Object Storage | 리전 | O | O |
+|  | Backup | 리전 | O | O |
+| Database | RDS for MySQL | 리전 | O |  |
+|  | RDS for MariaDB | 리전 | O |  |
+|  | EasyCache | 리전 | O |  |
+|  | MS-SQL Instance | 리전 | O | O |
+|  | MySQL Instance | 리전 | O | O |
+|  | PostgreSQL Instance | 리전 | O | O |
+|  | CUBRID Instance  | 리전 | O | O |
+|  | MariaDB Instance  | 리전 | O | O |
+|  | Tibero Instance   | 리전 | O | O |
+|  | Redis Instance | 리전 | O | O |
+|  | Valkey Instance | 리전 | O | O |
+| Monitoring | Cloud Monitoring | 글로벌 |  |  |
+| Security | Security Monitoring | 리전 | O |  |
+|  | Basic Security | 리전 | O | O |
+|  | Web Firewall | 리전 | O |  |
+|  | Vaccine | 리전 | O | O |
+|  | Secure Key Manager | 글로벌 |  |  |
+|  | Security Compliance | 글로벌 |  |  |
+|  | CSAP SaaS Guidance | 글로벌 |  |  |
+|  | SSL VPN | 리전 | O | O |
+|  | DDoS Guard | 리전 | O | O |
+|  | SIEM | 리전 | O |  |
+|  | Security Advisor | 글로벌 |  |  |
+|  | Network Firewall | 리전 | O |  |
+|  | NHN Bastion | 리전 | O |  |
+|  | Cloud Access | 리전 | O |  |
+| Content Delivery | CDN | 글로벌 |  |  |
+| Machine Learning | AI EasyMaker | 리전 | O |  |
+| Application Service | API Gateway | 리전 | O |  |
+| Data & Analytics | Log & Crash Search | 글로벌 |  |  |
+|  | Kafka Instance | 리전 | O | O |
+| Dev Tools | Pipeline | 리전 | O |  |
+|  | Deploy | 글로벌 |  |  |
+| Management | Certificate Manager | 글로벌 |  |  |
+| Collaboration | Dooray! | 글로벌 |  |  |
+| Governance & Audit | CloudTrail | 글로벌 |  |  |
+|  | Resource Watcher | 글로벌 |  |  |
+{%- else -%}
 | 분류 | 서비스명 | 글로벌/리전 서비스 | 한국(판교) 리전 | 한국(평촌) 리전 | 한국(광주) 리전 | 일본(도쿄) 리전 | 
 | --- | ---- | :--------: | :-------: | :-------: | :-------: | :----------: |
 | Compute | Instance | 리전 | O | O | O | O | 
@@ -158,3 +236,4 @@ NHN Cloud는 글로벌한 서비스 제공을 위해 더 많은 지역으로 리
 | Contact Center | Contiple | 글로벌 |  |  |  |  | 
 | Governance & Audit | CloudTrail | 글로벌 |  |  |  |  | 
 |  | Resource Watcher | 글로벌 |  |  |  |  | 
+{%- endif %}


### PR DESCRIPTION
## Summary

`ko/region-guide.md` + `ko/region-guide-gov.md` 를 build_flags 로 통합.

⚠️ **머지 금지** — 검증용 실험 PR.

## 통합 방식

- 인트로 문단 · 리전 개수 : inline `{% if %}` 로 "(공공기관용)" 브랜딩 및 "2개"/"4개" 분기
- `NHN Cloud 리전 위치` 섹션 (image 포함) : gov 에서 숨김 (섹션 wrap)
- `글로벌/리전별 제공 서비스` 표 : gov (2-region column, 74 rows) vs public (4-region column, 127 rows) — 컬럼 자체가 달라 표 전체를 조건 분기로 이중화. 표 밖 나머지 콘텐츠는 unconditional 공유
- Canonical markup unconditional

파일 크기: 160 → 239 lines (149%). 표 이중화 때문. 표 밖 뼈대는 여전히 unconditional 이라 concatenation 아님.

## 검증 결과

| build_flags | 결과 |
|---|---|
| (default → public) | **EXACT** |
| `gov` | **EXACT** |

## Preview 링크

| build_flags | 링크 |
|---|---|
| public | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=region-guide.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=region-guide-merge-20260806) |
| `gov` | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=region-guide.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=region-guide-merge-20260806&flags=gov) |
| 원본 `region-guide-gov.md` | [preview](http://content-agent.cloud.toastoven.net:7700/view?lang=ko&path=region-guide-gov.md&ko_repo=TOAST-DOCS/TOAST-Cloud&ko_ref=alpha) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
